### PR TITLE
Add Draw Area tool to dropdown menu

### DIFF
--- a/components/map-toggle.tsx
+++ b/components/map-toggle.tsx
@@ -29,6 +29,9 @@ export function MapToggle() {
         <DropdownMenuItem onClick={() => {setMapType(MapToggleEnum.RealTimeMode)}}>
           Live
         </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => {setMapType(MapToggleEnum.DrawArea)}}>
+          Draw Area
+        </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/components/map/mapbox-map.tsx
+++ b/components/map/mapbox-map.tsx
@@ -180,6 +180,26 @@ export const Mapbox: React.FC<{ position: { latitude: number; longitude: number;
     }
   }, [mapType]);
 
+  useEffect(() => {
+    const handleUndo = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key === 'z') {
+        const allDrawnFeatures = draw.getAll();
+        if (allDrawnFeatures.features.length > 0) {
+          const lastFeatureId = allDrawnFeatures.features[allDrawnFeatures.features.length - 1].id;
+          if (lastFeatureId) {
+            draw.delete(lastFeatureId);
+          }
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleUndo);
+
+    return () => {
+      document.removeEventListener('keydown', handleUndo);
+    };
+  }, []);
+
   return (
     <div className="h-full w-full overflow-hidden rounded-l-lg">
       <div


### PR DESCRIPTION
### **User description**
Add "Draw" Area tool to the drop-down menu and implement undo functionality.

* **Dropdown Menu:**
  - Add "Draw" Area tool to the dropdown menu in `components/map-toggle.tsx`.

* **Undo Functionality:**
  - Add event listener for "command + z" to undo the last action in `components/map/mapbox-map.tsx`.
  - Implement undo functionality using `draw.delete` method in `components/map/mapbox-map.tsx`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/QueueLab/mapgpt?shareId=ea8ed754-e1f1-4c0f-8d58-a301b40636ec).


___

### **PR Type**
enhancement


___

### **Description**
- Added a new "Draw Area" tool to the dropdown menu in `components/map-toggle.tsx`.
- Implemented undo functionality in `components/map/mapbox-map.tsx` using the "command + z" shortcut to delete the last drawn feature.
- Added an event listener to handle the undo action and remove the last drawn feature if available.



___



PRDescriptionHeader.CHANGES_WALKTHROUGH
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>map-toggle.tsx</strong><dd><code>Add "Draw Area" tool to dropdown menu</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/map-toggle.tsx

- Added "Draw Area" tool to the dropdown menu.



</details>


  </td>
  <td><a href="https://github.com/QueueLab/mapgpt/pull/75/files#diff-80429983cc555fc2edff59b488ff5dc258eb19568f03a5e71f2a3105302894ac">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mapbox-map.tsx</strong><dd><code>Implement undo functionality for drawing actions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/map/mapbox-map.tsx

<li>Implemented undo functionality for the draw tool.<br> <li> Added event listener for "command + z" to trigger undo.<br>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/mapgpt/pull/75/files#diff-ce7ea3ef85a6812c7da39941ffa47e8e0fadbb3fc7c391cf1cafd96303cf3a0f">+20/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information