### PR TITLE
Add Mapbox Draw tools and Turf visualizations

### DIFF
--- a/tests/mapbox.test.tsx
+++ b/tests/mapbox.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { Mapbox } from '../components/map/mapbox-map';
+
+describe('Mapbox Component', () => {
+  const position = { latitude: 37.7749, longitude: -122.4194 };
+
+  test('renders Mapbox component', () => {
+    render(<Mapbox position={position} />);
+    const mapElement = screen.getByRole('map');
+    expect(mapElement).toBeInTheDocument();
+  });
+
+  test('includes point, line, and rectangle drawing tools', () => {
+    render(<Mapbox position={position} />);
+    const pointTool = screen.getByLabelText('Draw Point');
+    const lineTool = screen.getByLabelText('Draw Line');
+    const rectangleTool = screen.getByLabelText('Draw Rectangle');
+    expect(pointTool).toBeInTheDocument();
+    expect(lineTool).toBeInTheDocument();
+    expect(rectangleTool).toBeInTheDocument();
+  });
+
+  test('includes visualization tools from Turf', () => {
+    render(<Mapbox position={position} />);
+    const bufferTool = screen.getByLabelText('Buffer');
+    const centroidTool = screen.getByLabelText('Centroid');
+    const convexTool = screen.getByLabelText('Convex');
+    expect(bufferTool).toBeInTheDocument();
+    expect(centroidTool).toBeInTheDocument();
+    expect(convexTool).toBeInTheDocument();
+  });
+
+  test('Mapbox is always available to preview', () => {
+    render(<Mapbox position={position} />);
+    const mapElement = screen.getByRole('map');
+    expect(mapElement).toBeInTheDocument();
+  });
+
+  test('keyboard shortcuts for drawing tools and visualization tools', () => {
+    render(<Mapbox position={position} />);
+    fireEvent.keyDown(document, { key: '1', ctrlKey: true });
+    const pointTool = screen.getByLabelText('Draw Point');
+    expect(pointTool).toHaveClass('active');
+
+    fireEvent.keyDown(document, { key: '2', ctrlKey: true });
+    const lineTool = screen.getByLabelText('Draw Line');
+    expect(lineTool).toHaveClass('active');
+
+    fireEvent.keyDown(document, { key: '3', ctrlKey: true });
+    const polygonTool = screen.getByLabelText('Draw Polygon');
+    expect(polygonTool).toHaveClass('active');
+
+    fireEvent.keyDown(document, { key: '4', ctrlKey: true });
+    const trashTool = screen.getByLabelText('Trash');
+    expect(trashTool).toHaveClass('active');
+
+    fireEvent.keyDown(document, { key: '5', ctrlKey: true });
+    const bufferTool = screen.getByLabelText('Buffer');
+    expect(bufferTool).toHaveClass('active');
+
+    fireEvent.keyDown(document, { key: '6', ctrlKey: true });
+    const centroidTool = screen.getByLabelText('Centroid');
+    expect(centroidTool).toHaveClass('active');
+
+    fireEvent.keyDown(document, { key: '7', ctrlKey: true });
+    const convexTool = screen.getByLabelText('Convex');
+    expect(convexTool).toHaveClass('active');
+  });
+});


### PR DESCRIPTION
### **User description**
Implement additional drawing tools and visualization tools from Mapbox Draw and Turf in the Mapbox component.

* Add point, line, and rectangle drawing tools from Mapbox Draw.
* Add visualization tools from Turf such as buffer, centroid, and convex.
* Update Mapbox dropdown to include controls for point, line, rectangle, polygon drawing, and trash.
* Add keyboard shortcuts for drawing tools and visualization tools.
* Add a mechanism for tools to be used together such as caching the state of a visualization.
* Add unit tests to ensure all drawing tools from Mapbox Draw and visualization tools from Turf are available.
* Add unit tests to ensure Mapbox is always available to preview.
* Add unit tests for keyboard shortcuts for drawing tools and visualization tools.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/QueueLab/mapgpt?shareId=22a84e8c-55bb-47ae-bb8f-676dba81ad52).


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Enhanced the Mapbox component by adding new drawing tools: point, line, and rectangle.
- Integrated Turf visualization tools including buffer, centroid, and convex functionalities.
- Implemented keyboard shortcuts for both drawing and visualization tools to improve user interaction.
- Added unit tests to verify the availability and functionality of the new tools and shortcuts.



___



PRDescriptionHeader.CHANGES_WALKTHROUGH
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mapbox-map.tsx</strong><dd><code>Enhance Mapbox with new drawing and visualization tools</code>&nbsp; &nbsp; </dd></summary>
<hr>

components/map/mapbox-map.tsx

<li>Added new drawing tools: point, line, and rectangle.<br> <li> Implemented keyboard shortcuts for drawing and visualization tools.<br> <li> Integrated Turf visualization tools: buffer, centroid, and convex.<br> <li> Added event listener for keyboard shortcuts.<br>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/mapgpt/pull/77/files#diff-ce7ea3ef85a6812c7da39941ffa47e8e0fadbb3fc7c391cf1cafd96303cf3a0f">+42/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mapbox.test.tsx</strong><dd><code>Add unit tests for Mapbox drawing and visualization tools</code></dd></summary>
<hr>

tests/mapbox.test.tsx

<li>Added unit tests for Mapbox component rendering.<br> <li> Tested inclusion of new drawing and visualization tools.<br> <li> Verified keyboard shortcuts functionality.<br>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/mapgpt/pull/77/files#diff-d462f164a3a03f2c685c34b67b3aa13a3087086e8570e84731efde3fd3eb6dbc">+71/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information