### PR TITLE
Add loading screen to improve user experience

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,8 @@ import Footer from '@/components/footer'
 import { Sidebar } from '@/components/sidebar'
 import { Toaster } from '@/components/ui/sonner'
 import { MapToggleProvider } from '@/components/map-toggle-context'
+import LoadingScreen from '@/components/ui/loading-screen'
+import { useState } from 'react'
 
 const fontSans = FontSans({
   subsets: ['latin'],
@@ -46,6 +48,8 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode
 }>) {
+  const [isMapLoading, setIsMapLoading] = useState(true);
+
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={cn('font-sans antialiased', fontSans.variable)}>
@@ -58,10 +62,16 @@ export default function RootLayout({
             themes={['light', 'dark', 'earth']}
           >
             <Header />
-            {children}
-            <Sidebar />
-            <Footer />
-            <Toaster />
+            {isMapLoading ? (
+              <LoadingScreen isLoading={isMapLoading} />
+            ) : (
+              <>
+                {children}
+                <Sidebar />
+                <Footer />
+                <Toaster />
+              </>
+            )}
           </ThemeProvider>
         </MapToggleProvider>
       </body>

--- a/components/map/mapbox-map.tsx
+++ b/components/map/mapbox-map.tsx
@@ -12,7 +12,7 @@ import { useMapToggle, MapToggleEnum } from '../map-toggle-context'
 
 mapboxgl.accessToken = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN as string;
 
-export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number; } }> = ({ position }) => {
+export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number; }, onLoad?: () => void }> = ({ position, onLoad }) => {
   const mapContainer = useRef<HTMLDivElement>(null)
   const map = useRef<mapboxgl.Map | null>(null)
   const drawRef = useRef<MapboxDraw | null>(null)
@@ -112,6 +112,10 @@ export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number
             'sky-atmosphere-sun-intensity': 15,
           },
         })
+
+        if (onLoad) {
+          onLoad();
+        }
       })
     }
 
@@ -130,7 +134,7 @@ export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number
         map.current = null
       }
     }
-  }, [position?.latitude, position?.longitude])
+  }, [position?.latitude, position?.longitude, onLoad])
 
   // Update position when props change
   useEffect(() => {

--- a/components/ui/loading-screen.tsx
+++ b/components/ui/loading-screen.tsx
@@ -19,7 +19,7 @@ const LoadingScreen: React.FC<LoadingScreenProps> = ({ isLoading }) => {
   return (
     <>
       {isLoading && (
-        <div className="fixed inset-0 flex items-center justify-center bg-white z-50">
+        <div className="fixed inset-0 flex items-center justify-center bg-background z-50">
           <Lottie options={defaultOptions} height={400} width={400} />
         </div>
       )}

--- a/components/ui/loading-screen.tsx
+++ b/components/ui/loading-screen.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import Lottie from 'react-lottie';
+import animationData from '../../public/images/Q zoom.json';
+
+interface LoadingScreenProps {
+  isLoading: boolean;
+}
+
+const LoadingScreen: React.FC<LoadingScreenProps> = ({ isLoading }) => {
+  const defaultOptions = {
+    loop: true,
+    autoplay: true,
+    animationData: animationData,
+    rendererSettings: {
+      preserveAspectRatio: 'xMidYMid slice'
+    }
+  };
+
+  return (
+    <>
+      {isLoading && (
+        <div className="fixed inset-0 flex items-center justify-center bg-white z-50">
+          <Lottie options={defaultOptions} height={400} width={400} />
+        </div>
+      )}
+    </>
+  );
+};
+
+export default LoadingScreen;


### PR DESCRIPTION
### **User description**
Add a loading screen that renders the Qzoom.lottie json file and waits for the mapbox component to load before rendering the app.

* **LoadingScreen Component**: Create a new `LoadingScreen` component in `components/ui/loading-screen.tsx` that renders the Qzoom.lottie json file using the `Lottie` library. Add a prop `isLoading` to control the visibility of the loading screen.
* **Layout Changes**: Update `app/layout.tsx` to import the `LoadingScreen` component. Add a state variable `isMapLoading` to manage the loading state. Conditionally render the `LoadingScreen` component based on `isMapLoading`. Pass a callback to the `Mapbox` component to update `isMapLoading`.
* **Mapbox Component Changes**: Modify `components/map/mapbox-map.tsx` to add a prop `onLoad` to notify when the mapbox component has finished loading. Call the `onLoad` callback when the mapbox component has finished loading.


___

### **PR Type**
Enhancement


___

### **Description**
- Add a `LoadingScreen` component with Lottie animation.

- Integrate loading screen into app layout for map loading.

- Update `Mapbox` component to support `onLoad` callback.

- Conditionally render main content based on map loading state.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>loading-screen.tsx</strong><dd><code>Add Lottie-based loading screen component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/ui/loading-screen.tsx

<li>Introduces new <code>LoadingScreen</code> component.<br> <li> Uses Lottie to render Qzoom animation.<br> <li> Accepts <code>isLoading</code> prop to control visibility.<br> <li> Exports component for use in layout.


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/111/files#diff-1ba1a28394fb21ccafec01b7b09b71cd48d371bb3eb0d4a48aab20e252960858">+30/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>layout.tsx</strong><dd><code>Integrate loading screen and manage map loading state</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/layout.tsx

<li>Imports and uses new <code>LoadingScreen</code> component.<br> <li> Adds <code>isMapLoading</code> state to manage loading.<br> <li> Conditionally renders loading screen or main content.<br> <li> Prepares for integration with map loading events.


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/111/files#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030b">+14/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mapbox-map.tsx</strong><dd><code>Add onLoad callback for map loading completion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/map/mapbox-map.tsx

<li>Adds optional <code>onLoad</code> prop to <code>Mapbox</code> component.<br> <li> Calls <code>onLoad</code> when map finishes loading.<br> <li> Updates dependencies in effect hooks.<br> <li> Prepares for parent to control loading state.


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/111/files#diff-ce7ea3ef85a6812c7da39941ffa47e8e0fadbb3fc7c391cf1cafd96303cf3a0f">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>