### PR TITLE
Add loading screen with Qzoom.lottie animation

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import type { Metadata, Viewport } from 'next'
 import { Inter as FontSans } from 'next/font/google'
 import './globals.css'
@@ -16,32 +18,8 @@ const fontSans = FontSans({
   variable: '--font-sans'
 })
 
-const title = 'QCX'
-const description =
-  'language to Maps'
-
-export const metadata: Metadata = {
-  metadataBase: new URL('https://labs.queue.cx'),
-  title,
-  description,
-  openGraph: {
-    title,
-    description
-  },
-  twitter: {
-    title,
-    description,
-    card: 'summary_large_image',
-    creator: '@queuelabs'
-  }
-}
-
-export const viewport: Viewport = {
-  width: 'device-width',
-  initialScale: 1,
-  minimumScale: 1,
-  maximumScale: 1
-}
+// Note: You can't use metadata or viewport exports in client components
+// So we'll need to define these differently
 
 export default function RootLayout({
   children

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,8 @@ import Footer from '@/components/footer'
 import { Sidebar } from '@/components/sidebar'
 import { Toaster } from '@/components/ui/sonner'
 import { MapToggleProvider } from '@/components/map-toggle-context'
+import LoadingScreen from '@/components/ui/loading-screen'
+import { useState } from 'react'
 
 const fontSans = FontSans({
   subsets: ['latin'],
@@ -46,6 +48,8 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode
 }>) {
+  const [isMapLoading, setIsMapLoading] = useState(true);
+
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={cn('font-sans antialiased', fontSans.variable)}>
@@ -57,6 +61,7 @@ export default function RootLayout({
             disableTransitionOnChange
             themes={['light', 'dark', 'earth']}
           >
+            <LoadingScreen isLoading={isMapLoading} />
             <Header />
             {children}
             <Sidebar />

--- a/components/map/mapbox-map.tsx
+++ b/components/map/mapbox-map.tsx
@@ -12,7 +12,7 @@ import { useMapToggle, MapToggleEnum } from '../map-toggle-context'
 
 mapboxgl.accessToken = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN as string;
 
-export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number; } }> = ({ position }) => {
+export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number; }, onLoad?: () => void }> = ({ position, onLoad }) => {
   const mapContainer = useRef<HTMLDivElement>(null)
   const map = useRef<mapboxgl.Map | null>(null)
   const drawRef = useRef<MapboxDraw | null>(null)
@@ -418,6 +418,10 @@ export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number
 
         initializedRef.current = true
         setupGeolocationWatcher()
+
+        if (onLoad) {
+          onLoad();
+        }
       })
     }
 

--- a/components/ui/loading-screen.tsx
+++ b/components/ui/loading-screen.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import Lottie from 'react-lottie';
+import animationData from '../../public/images/Q zoom.json';
+
+interface LoadingScreenProps {
+  isLoading: boolean;
+}
+
+const LoadingScreen: React.FC<LoadingScreenProps> = ({ isLoading }) => {
+  const defaultOptions = {
+    loop: true,
+    autoplay: true,
+    animationData: animationData,
+    rendererSettings: {
+      preserveAspectRatio: 'xMidYMid slice'
+    }
+  };
+
+  return (
+    <div style={{ display: isLoading ? 'block' : 'none' }}>
+      <Lottie options={defaultOptions} height={400} width={400} />
+    </div>
+  );
+};
+
+export default LoadingScreen;


### PR DESCRIPTION
### **User description**
Add a loading screen that displays Qzoom.lottie animation and waits for Mapbox to load before rendering the app.

* **LoadingScreen Component**: Create `components/ui/loading-screen.tsx` to render Qzoom.lottie using Lottie library. Add `isLoading` prop to control visibility.
* **Layout Changes**: Update `app/layout.tsx` to import `LoadingScreen`, add `isMapLoading` state, and conditionally render `LoadingScreen` based on `isMapLoading`.
* **Mapbox Component Changes**: Modify `components/map/mapbox-map.tsx` to add `onLoad` prop and call `onLoad` callback on load completion.


___

### **PR Type**
Enhancement


___

### **Description**
- Introduced a loading screen with Qzoom.lottie animation.

- Added `LoadingScreen` component to manage loading state.

- Updated `RootLayout` to conditionally render `LoadingScreen`.

- Enhanced `Mapbox` component with `onLoad` callback functionality.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>layout.tsx</strong><dd><code>Integrated loading screen into application layout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/layout.tsx

<li>Imported <code>LoadingScreen</code> component and <code>useState</code> hook.<br> <li> Added <code>isMapLoading</code> state to manage loading visibility.<br> <li> Integrated <code>LoadingScreen</code> into the layout with conditional rendering.


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/113/files#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030b">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mapbox-map.tsx</strong><dd><code>Enhanced Mapbox component with onLoad callback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/map/mapbox-map.tsx

<li>Added <code>onLoad</code> prop to <code>Mapbox</code> component.<br> <li> Triggered <code>onLoad</code> callback after Mapbox initialization.<br> <li> Enhanced component to support loading state management.


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/113/files#diff-ce7ea3ef85a6812c7da39941ffa47e8e0fadbb3fc7c391cf1cafd96303cf3a0f">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>loading-screen.tsx</strong><dd><code>Added LoadingScreen component with Lottie animation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/ui/loading-screen.tsx

<li>Created <code>LoadingScreen</code> component using Lottie library.<br> <li> Configured animation options for Qzoom.lottie.<br> <li> Added <code>isLoading</code> prop to control visibility.


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/113/files#diff-1ba1a28394fb21ccafec01b7b09b71cd48d371bb3eb0d4a48aab20e252960858">+26/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>