### PR TITLE
feat: Add chat history toggle to mobile UI

### DIFF
--- a/components/mobile-icons-bar.tsx
+++ b/components/mobile-icons-bar.tsx
@@ -11,6 +11,7 @@ import {
   Paperclip,
   ArrowRight
 } from 'lucide-react'
+import { History } from '@/components/history'
 import { MapToggle } from './map-toggle'
 import { ModeToggle } from './mode-toggle'
 
@@ -36,6 +37,7 @@ export const MobileIconsBar: React.FC = () => {
       <Button variant="ghost" size="icon">
         <ArrowRight className="h-[1.2rem] w-[1.2rem] transition-all rotate-0 scale-100" />
       </Button>
+      <History location="header" />
       <ModeToggle />
     </div>
   )


### PR DESCRIPTION
### **User description**
This commit introduces a chat history toggle icon to the mobile icon bar. The icon is the same as the one used in the desktop app (Menu icon) and allows you to open and close the chat history panel on mobile devices.

The `History` component was added to `components/mobile-icons-bar.tsx` with the `location="header"` prop to ensure correct icon display and functionality.


___

### **PR Type**
Enhancement


___

### **Description**
- Added chat history toggle icon to mobile icon bar

- Integrated `History` component with `location="header"` prop

- Ensured consistent icon usage with desktop app


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mobile-icons-bar.tsx</strong><dd><code>Add chat history toggle icon to mobile UI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/mobile-icons-bar.tsx

<li>Imported <code>History</code> component for use in mobile UI<br> <li> Added <code>History</code> icon to the mobile icons bar with <code>location="header"</code><br> <li> Ensured chat history toggle is accessible on mobile devices


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/145/files#diff-9f258d33f15a037a252e9debe448117217cb455ef07d7e024426ab00e7f90851">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>