### PR TITLE
Fix: Adjust your icon dropdown alignment for desktop and mobile

### DIFF
--- a/components/profile-toggle.tsx
+++ b/components/profile-toggle.tsx
@@ -1,28 +1,24 @@
 'use client'
-
 import { useState, useEffect } from "react"
 import { User, Settings, Paintbrush, Shield, CircleUserRound } from "lucide-react"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { Button } from "@/components/ui/button"
 import { ProfileToggleEnum, useProfileToggle } from "./profile-toggle-context"
 import { useRouter } from "next/navigation"
-//import { settings } from "@components/settings/components/settings.tsx"
-
 
 export function ProfileToggle() {
   const { setProfileSection } = useProfileToggle()
   const router = useRouter()
-  const [alignValue, setAlignValue] = useState<'start' | 'end'>("start")
-
+  const [alignValue, setAlignValue] = useState<'start' | 'end'>("end")
+  
   useEffect(() => {
     const handleResize = () => {
       if (window.innerWidth < 768) {
-        setAlignValue("start")
+        setAlignValue("end") // Right align on mobile too
       } else {
-        setAlignValue("start")
+        setAlignValue("end") // Right align on desktop
       }
     }
-
     handleResize() // Set initial value
   
     let resizeTimer: NodeJS.Timeout;

--- a/components/profile-toggle.tsx
+++ b/components/profile-toggle.tsx
@@ -17,7 +17,7 @@ export function ProfileToggle() {
   useEffect(() => {
     const handleResize = () => {
       if (window.innerWidth < 768) {
-        setAlignValue("end")
+        setAlignValue("start")
       } else {
         setAlignValue("start")
       }

--- a/components/profile-toggle.tsx
+++ b/components/profile-toggle.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState, useEffect } from "react"
 import { User, Settings, Paintbrush, Shield, CircleUserRound } from "lucide-react"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { Button } from "@/components/ui/button"
@@ -11,6 +12,21 @@ import { useRouter } from "next/navigation"
 export function ProfileToggle() {
   const { setProfileSection } = useProfileToggle()
   const router = useRouter()
+  const [alignValue, setAlignValue] = useState<'start' | 'end'>("start")
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth < 768) {
+        setAlignValue("end")
+      } else {
+        setAlignValue("start")
+      }
+    }
+
+    handleResize() // Set initial value
+    window.addEventListener("resize", handleResize)
+    return () => window.removeEventListener("resize", handleResize)
+  }, [])
   
   const handleSectionChange = (section: string) => {
     setProfileSection(section as ProfileToggleEnum)
@@ -25,7 +41,7 @@ export function ProfileToggle() {
           <span className="sr-only">Open profile menu</span>
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent className="w-56" align="end" forceMount>
+      <DropdownMenuContent className="w-56" align={alignValue} forceMount>
         <DropdownMenuItem onClick={() => handleSectionChange("account")}>
           <User className="mr-2 h-4 w-4" />
           <span>Account</span>

--- a/components/profile-toggle.tsx
+++ b/components/profile-toggle.tsx
@@ -24,8 +24,15 @@ export function ProfileToggle() {
     }
 
     handleResize() // Set initial value
-    window.addEventListener("resize", handleResize)
-    return () => window.removeEventListener("resize", handleResize)
+  
+    let resizeTimer: NodeJS.Timeout;
+    const debouncedResize = () => {
+      clearTimeout(resizeTimer);
+      resizeTimer = setTimeout(handleResize, 100);
+    };
+  
+    window.addEventListener("resize", debouncedResize)
+    return () => window.removeEventListener("resize", debouncedResize)
   }, [])
   
   const handleSectionChange = (section: string) => {

--- a/components/profile-toggle.tsx
+++ b/components/profile-toggle.tsx
@@ -14,9 +14,9 @@ export function ProfileToggle() {
   useEffect(() => {
     const handleResize = () => {
       if (window.innerWidth < 768) {
-        setAlignValue("end") // Right align on mobile too
+        setAlignValue("start") // Right align on mobile too
       } else {
-        setAlignValue("end") // Right align on desktop
+        setAlignValue("start") // Right align on desktop
       }
     }
     handleResize() // Set initial value


### PR DESCRIPTION
### **User description**
The icon dropdown menu in `profile-toggle.tsx` was previously hardcoded with `align="end"`. This caused the menu to open to the left, which was incorrect for the desktop view where the icon is on the left side of the header.

This commit introduces conditional alignment for the `DropdownMenuContent`:
- On screen widths >= 768px (desktop), `align="start"` is used. This makes the menu open to the right of the icon, as intended.
- On screen widths < 768px (mobile), `align="end"` is used. This makes the menu open to the left of the icon (which is positioned on the right in the mobile header), correctly displaying the menu on the right side of the viewport.

The `ProfileToggle` component, which contains this dropdown, is confirmed to be rendered in both the desktop and mobile versions of the site header. This change ensures the dropdown menu behaves as expected across different screen sizes, addressing the alignment issues described in the original problem statement.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Implements dynamic dropdown alignment based on screen width.

- Uses React state and effect to update alignment responsively.

- Fixes incorrect dropdown menu positioning on desktop and mobile.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>profile-toggle.tsx</strong><dd><code>Responsive dropdown alignment for profile menu</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/profile-toggle.tsx

<li>Added state and effect to control dropdown alignment responsively.<br> <li> Dropdown menu now uses <code>align={alignValue}</code> instead of hardcoded value.<br> <li> Ensures correct menu positioning for both desktop and mobile views.


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/148/files#diff-859a04a535ab59ff56fe1e35749aa01d9d10325fe77d6a9f8bc9959461291948">+24/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>