### PR TITLE
Fix: Align settings dropdown to left on mobile

### DIFF
--- a/components/profile-toggle.tsx
+++ b/components/profile-toggle.tsx
@@ -1,5 +1,4 @@
 'use client'
-import { useState, useEffect } from "react"
 import { User, Settings, Paintbrush, Shield, CircleUserRound } from "lucide-react"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { Button } from "@/components/ui/button"
@@ -7,27 +6,6 @@ import { ProfileToggleEnum, useProfileToggle } from "./profile-toggle-context"
 
 export function ProfileToggle() {
   const { toggleProfileSection } = useProfileToggle()
-  const [alignValue, setAlignValue] = useState<'start' | 'end'>("end")
-  
-  useEffect(() => {
-    const handleResize = () => {
-      if (window.innerWidth < 768) {
-        setAlignValue("start") // Right align on mobile too
-      } else {
-        setAlignValue("start") // Right align on desktop
-      }
-    }
-    handleResize() // Set initial value
-  
-    let resizeTimer: NodeJS.Timeout;
-    const debouncedResize = () => {
-      clearTimeout(resizeTimer);
-      resizeTimer = setTimeout(handleResize, 100);
-    };
-  
-    window.addEventListener("resize", debouncedResize)
-    return () => window.removeEventListener("resize", debouncedResize)
-  }, [])
   
   const handleSectionChange = (section: ProfileToggleEnum) => {
     toggleProfileSection(section)
@@ -41,7 +19,12 @@ export function ProfileToggle() {
           <span className="sr-only">Open profile menu</span>
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent className="w-56" align={alignValue} forceMount>
+      <DropdownMenuContent
+        className="w-56"
+        align="end" // Default alignment for desktop
+        alignOnMobile={true} // Enable mobile-specific alignment
+        forceMount
+      >
         <DropdownMenuItem onClick={() => handleSectionChange(ProfileToggleEnum.Account)}>
           <User className="mr-2 h-4 w-4" />
           <span>Account</span>

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -87,10 +87,17 @@ const DropdownMenuContent = React.forwardRef<
       }
       // Initial check
       checkMobile()
-      // Listen for window resize
-      window.addEventListener('resize', checkMobile)
+  
+      let resizeTimer: NodeJS.Timeout;
+      const debouncedResize = () => {
+        clearTimeout(resizeTimer);
+        resizeTimer = setTimeout(checkMobile, 100);
+      };
+  
+      // Listen for window resize with debouncing
+      window.addEventListener('resize', debouncedResize)
       // Cleanup
-      return () => window.removeEventListener('resize', checkMobile)
+      return () => window.removeEventListener('resize', debouncedResize)
     }, [])
 
     // On mobile with alignOnMobile enabled, use 'start' alignment to position on the left

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -56,22 +56,65 @@ const DropdownMenuSubContent = React.forwardRef<
 DropdownMenuSubContent.displayName =
   DropdownMenuPrimitive.SubContent.displayName
 
+// Define new props interface
+interface DropdownMenuContentProps
+  extends React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content> {
+  alignOnMobile?: boolean
+  // side and align are already part of DropdownMenuPrimitive.Content,
+  // so they are inherited. We just need to provide defaults or override them.
+}
+
 const DropdownMenuContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
-  <DropdownMenuPrimitive.Portal>
-    <DropdownMenuPrimitive.Content
-      ref={ref}
-      sideOffset={sideOffset}
-      className={cn(
-        'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-        className
-      )}
-      {...props}
-    />
-  </DropdownMenuPrimitive.Portal>
-))
+  DropdownMenuContentProps
+>(
+  (
+    {
+      className,
+      sideOffset = 4,
+      alignOnMobile,
+      side: initialSide = 'bottom', // Default side
+      align: initialAlign = 'center', // Default align
+      ...props
+    },
+    ref
+  ) => {
+    const [isMobile, setIsMobile] = React.useState(false)
+
+    React.useEffect(() => {
+      const checkMobile = () => {
+        setIsMobile(window.innerWidth < 768)
+      }
+      // Initial check
+      checkMobile()
+      // Listen for window resize
+      window.addEventListener('resize', checkMobile)
+      // Cleanup
+      return () => window.removeEventListener('resize', checkMobile)
+    }, [])
+
+    const side = alignOnMobile && isMobile ? 'left' : initialSide
+    // If side is 'left' due to mobile alignment, align to 'end' to make it appear left of trigger.
+    // Otherwise, use the initialAlign.
+    const align = side === 'left' && alignOnMobile && isMobile ? 'end' : initialAlign
+
+    return (
+      <DropdownMenuPrimitive.Portal>
+        <DropdownMenuPrimitive.Content
+          ref={ref}
+          sideOffset={sideOffset}
+          side={side}
+          align={align}
+          className={cn(
+            'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+            className
+          )}
+          {...props}
+        />
+      </DropdownMenuPrimitive.Portal>
+    )
+  }
+)
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
 
 const DropdownMenuItem = React.forwardRef<

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -93,10 +93,9 @@ const DropdownMenuContent = React.forwardRef<
       return () => window.removeEventListener('resize', checkMobile)
     }, [])
 
-    const side = alignOnMobile && isMobile ? 'left' : initialSide
-    // If side is 'left' due to mobile alignment, align to 'end' to make it appear left of trigger.
-    // Otherwise, use the initialAlign.
-    const align = side === 'left' && alignOnMobile && isMobile ? 'end' : initialAlign
+    // On mobile with alignOnMobile enabled, use 'start' alignment to position on the left
+    // Otherwise, use the provided initialAlign
+    const align = alignOnMobile && isMobile ? 'start' : initialAlign
 
     return (
       <DropdownMenuPrimitive.Portal>


### PR DESCRIPTION
### **User description**
The settings dropdown menu in the header was previously rendering off-screen on mobile devices because it defaulted to opening on the right.

This commit introduces the following changes:

1.  Modified `components/ui/dropdown-menu.tsx`:
    *   Added an `alignOnMobile?: boolean` prop to `DropdownMenuContent`.
    *   When `alignOnMobile` is true and the viewport is detected as mobile (width < 768px), the `DropdownMenuContent` now dynamically sets its `side` prop to "left" and `align` prop to "end". This ensures it opens to the left of the trigger.
    *   Viewport width is checked using `window.innerWidth` within a `useEffect` hook.

2.  Updated `components/profile-toggle.tsx`:
    *   Passed `alignOnMobile={true}` to the `DropdownMenuContent` used for the profile/settings icon.
    *   Removed redundant local logic for responsive alignment, as this is now handled by `DropdownMenuContent`.
    *   Set a default `align="end"` for desktop view.

The `z-index` of the dropdown (`z-50`) was already higher than the mobile chat input (`z-30`) and icons bar (`z-20`), so no CSS changes were needed in `app/globals.css` for stacking.

These changes ensure the settings dropdown is correctly positioned and visible on mobile devices, appearing to the left of its icon and on top of the chat input area.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added responsive alignment to `DropdownMenuContent` for mobile devices
  - Introduced `alignOnMobile` prop to handle mobile-specific alignment
  - Dropdown now opens to the left and aligns to end on mobile

- Refactored `ProfileToggle` to use new dropdown alignment logic
  - Removed redundant alignment state and effect logic
  - Set default desktop alignment and enabled mobile alignment


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dropdown-menu.tsx</strong><dd><code>Add mobile-aware alignment to DropdownMenuContent</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/ui/dropdown-menu.tsx

<li>Added <code>alignOnMobile</code> prop to <code>DropdownMenuContent</code><br> <li> Implemented mobile detection and dynamic alignment logic<br> <li> Refactored component to override <code>side</code> and <code>align</code> on mobile<br> <li> Updated prop interface and usage accordingly


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/151/files#diff-bc12d3573eefdb106075087f78e9340cc65ae99a33961f8400c48a3f4dee2611">+57/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>profile-toggle.tsx</strong><dd><code>Refactor ProfileToggle to use responsive dropdown alignment</code></dd></summary>
<hr>

components/profile-toggle.tsx

<li>Removed local alignment state and effect logic<br> <li> Passed <code>alignOnMobile={true}</code> to <code>DropdownMenuContent</code><br> <li> Set default desktop alignment to "end"<br> <li> Simplified dropdown rendering logic


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/151/files#diff-859a04a535ab59ff56fe1e35749aa01d9d10325fe77d6a9f8bc9959461291948">+6/-23</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>