### PR TITLE
Fix: Remove extra profile icon from MobileIconsBar

### DIFF
--- a/components/mobile-icons-bar.tsx
+++ b/components/mobile-icons-bar.tsx
@@ -18,9 +18,6 @@ import { ModeToggle } from './mode-toggle'
 export const MobileIconsBar: React.FC = () => {
   return (
     <div className="mobile-icons-bar-content">
-      <Button variant="ghost" size="icon">
-        <CircleUserRound className="h-[1.2rem] w-[1.2rem]" />
-      </Button>
       <MapToggle />
       <Button variant="ghost" size="icon">
         <CalendarDays className="h-[1.2rem] w-[1.2rem] transition-all rotate-0 scale-100" />


### PR DESCRIPTION
### **User description**
Removes a redundant CircleUserRound icon from the MobileIconsBar component. This icon was causing an extra profile icon to appear on mobile layouts, as the main Header component already includes a ProfileToggle component for handling profile-related actions on both mobile and desktop views.

The issue was identified as the MobileIconsBar rendering a standalone profile icon, while the Header component also renders the ProfileToggle. This commit removes the standalone icon in MobileIconsBar, ensuring the ProfileToggle in the Header is the single source for the profile icon and its associated functionality.

Output:


___

### **PR Type**
Bug fix


___

### **Description**
- Removes redundant profile icon from `MobileIconsBar`

- Ensures only `ProfileToggle` in `Header` handles profile actions

- Prevents duplicate profile icons on mobile layouts


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mobile-icons-bar.tsx</strong><dd><code>Remove redundant profile icon button from MobileIconsBar</code>&nbsp; </dd></summary>
<hr>

components/mobile-icons-bar.tsx

<li>Deleted standalone profile icon button from the mobile icons bar<br> <li> Prevents duplicate profile icon display on mobile devices


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/152/files#diff-9f258d33f15a037a252e9debe448117217cb455ef07d7e024426ab00e7f90851">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>