### PR TITLE
feat: Implement smooth fade-in for streamed AI responses

### DIFF
--- a/components/message.tsx
+++ b/components/message.tsx
@@ -2,6 +2,7 @@
 
 import { StreamableValue, useStreamableValue } from 'ai/rsc'
 import { MemoizedReactMarkdown } from './ui/markdown'
+import { useEffect, useState } from 'react'
 import rehypeExternalLinks from 'rehype-external-links'
 import remarkGfm from 'remark-gfm'
 import remarkMath from 'remark-math'
@@ -10,6 +11,13 @@ import 'katex/dist/katex.min.css'
 
 export function BotMessage({ content }: { content: StreamableValue<string> }) {
   const [data, error, pending] = useStreamableValue(content)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    if (data && !isVisible) {
+      setIsVisible(true)
+    }
+  }, [data, isVisible])
 
   // Currently, sometimes error occurs after finishing the stream.
   if (error) return <div>Error</div>
@@ -18,13 +26,20 @@ export function BotMessage({ content }: { content: StreamableValue<string> }) {
   const processedData = preprocessLaTeX(data || '')
 
   return (
-    <MemoizedReactMarkdown
-      rehypePlugins={[[rehypeExternalLinks, { target: '_blank' }], rehypeKatex]}
-      remarkPlugins={[remarkGfm, remarkMath]}
-      className="prose-sm prose-neutral prose-a:text-accent-foreground/50"
+    <div
+      style={{
+        opacity: isVisible ? 1 : 0,
+        transition: 'opacity 0.5s ease-in-out'
+      }}
     >
-      {processedData}
-    </MemoizedReactMarkdown>
+      <MemoizedReactMarkdown
+        rehypePlugins={[[rehypeExternalLinks, { target: '_blank' }], rehypeKatex]}
+        remarkPlugins={[remarkGfm, remarkMath]}
+        className="prose-sm prose-neutral prose-a:text-accent-foreground/50"
+      >
+        {processedData}
+      </MemoizedReactMarkdown>
+    </div>
   )
 }
 


### PR DESCRIPTION
This commit introduces a fade-in animation for messages generated by the AI. The `BotMessage` component in `components/message.tsx` has been updated to gradually reveal new messages, enhancing your experience by providing a smoother visual transition as text is streamed.

The animation is achieved using a CSS opacity transition, triggered once when the message content begins to stream. This ensures that the application remains responsive and the streaming remains concurrent. Manual testing confirmed that the effect is smooth and works correctly for various message types, including short, long, Markdown, and LaTeX content.