### PR TITLE
feat: Adjust initial Earth view and rotation

### DIFF
--- a/components/map/mapbox-map.tsx
+++ b/components/map/mapbox-map.tsx
@@ -140,7 +140,7 @@ export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number
   const rotateMap = useCallback(() => {
     if (map.current && isRotatingRef.current && !isUpdatingPositionRef.current) {
       const bearing = map.current.getBearing()
-      map.current.setBearing(bearing - 0.1)
+      map.current.setBearing(bearing + 0.1)
       rotationFrameRef.current = requestAnimationFrame(rotateMap)
     }
   }, [])

--- a/components/map/mapbox-map.tsx
+++ b/components/map/mapbox-map.tsx
@@ -26,8 +26,8 @@ export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number
   const geolocationWatchIdRef = useRef<number | null>(null)
   const initializedRef = useRef<boolean>(false)
   const currentMapCenterRef = useRef<[number, number]>([
-    position?.longitude ?? -74.0060152,
-    position?.latitude ?? 40.7127281
+    position?.longitude ?? 0,
+    position?.latitude ?? 0
   ])
   const drawingFeatures = useRef<any>(null)
   const { mapType } = useMapToggle()
@@ -140,7 +140,7 @@ export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number
   const rotateMap = useCallback(() => {
     if (map.current && isRotatingRef.current && !isUpdatingPositionRef.current) {
       const bearing = map.current.getBearing()
-      map.current.setBearing(bearing + 0.1)
+      map.current.setBearing(bearing - 0.1)
       rotationFrameRef.current = requestAnimationFrame(rotateMap)
     }
   }, [])
@@ -366,9 +366,9 @@ export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number
         container: mapContainer.current,
         style: 'mapbox://styles/mapbox/satellite-streets-v12',
         center: currentMapCenterRef.current,
-        zoom: 12,
-        pitch: 60,
-        bearing: -20,
+        zoom: 2,
+        pitch: 0,
+        bearing: 0,
         maxZoom: 22,
         attributionControl: true
       })

--- a/components/map/mapbox-map.tsx
+++ b/components/map/mapbox-map.tsx
@@ -362,11 +362,16 @@ export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number
   // Initialize map (only once)
   useEffect(() => {
     if (mapContainer.current && !map.current) {
+      let initialZoom = 2;
+      if (typeof window !== 'undefined' && window.innerWidth < 768) {
+        initialZoom = 1.3;
+      }
+
       map.current = new mapboxgl.Map({
         container: mapContainer.current,
         style: 'mapbox://styles/mapbox/satellite-streets-v12',
         center: currentMapCenterRef.current,
-        zoom: 2,
+        zoom: initialZoom,
         pitch: 0,
         bearing: 0,
         maxZoom: 22,


### PR DESCRIPTION
### **User description**
Modifies the map component to:
1. Initialize with a zoomed-out view, showing the Earth as a sphere.
   - Sets initial zoom to 2.
   - Sets initial center to [0, 0] (longitude, latitude).
   - Sets initial pitch to 0.
   - Sets initial bearing to 0.
2. Change the automatic rotation direction to be from left to right (east to west).

These changes provide the desired initial loading experience where the Earth is displayed as a spinning sphere.


___

### **PR Type**
Enhancement


___

### **Description**
- Set initial map view to show entire Earth as a sphere
  - Center at [0, 0], zoom level 2, pitch 0, bearing 0

- Reverse automatic map rotation direction (east to west)


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mapbox-map.tsx</strong><dd><code>Set initial global Earth view and reverse rotation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/map/mapbox-map.tsx

<li>Changed initial map center to [0, 0] (longitude, latitude)<br> <li> Set initial zoom to 2, pitch to 0, bearing to 0 for a global view<br> <li> Modified map rotation to move bearing from left to right (east to <br>west)


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/166/files#diff-ce7ea3ef85a6812c7da39941ffa47e8e0fadbb3fc7c391cf1cafd96303cf3a0f">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>