### PR TITLE
Fix: Adjust desktop chat area height to match map render height

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -124,15 +124,37 @@
     min-width: max-content;
   }
 
+  /*
   .mobile-chat-section {
-    flex: 1; /* Take remaining space */
+    flex: 1; 
     width: 100%;
     overflow-y: auto;
     padding: 12px;
-    padding-bottom: 60px; /* Space for the chat input */
+    padding-bottom: 60px; 
     box-sizing: border-box;
     background-color: hsl(var(--card));
     color: hsl(var(--card-foreground));
+  }
+  */
+
+  .mobile-chat-messages-area {
+    height: 40vh;
+    overflow-y: auto;
+    padding: 12px;
+    background-color: hsl(var(--card));
+    color: hsl(var(--card-foreground));
+    box-sizing: border-box;
+  }
+
+  .mobile-chat-input-area {
+    height: 70px;
+    padding: 10px;
+    background-color: hsl(var(--background));
+    border-top: 1px solid hsl(var(--border));
+    box-sizing: border-box;
+    z-index: 30;
+    display: flex;
+    align-items: center;
   }
 
   .mobile-chat-input {

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -98,13 +98,13 @@ export function ChatPanel({ messages }: ChatPanelProps) {
       className={cn(
         'flex flex-col items-start',
         isMobile
-          ? 'w-full'
+          ? 'w-full h-full'
           : 'sticky bottom-0 bg-background z-10 w-full border-t border-border px-2 py-3 md:px-4'
       )}
     >
       <form
         onSubmit={handleSubmit}
-        className={cn('max-w-full w-full', isMobile ? 'px-2 pb-2 pt-1' : '')}
+        className={cn('max-w-full w-full', isMobile ? 'px-2 pb-2 pt-1 h-full flex flex-col justify-center' : '')}
       >
         <div
           className={cn(

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -63,8 +63,10 @@ export function Chat({ id }: ChatProps) {
           <div className="mobile-icons-bar">
             <MobileIconsBar />
           </div>
-          <div className="mobile-chat-section">
+          <div className="mobile-chat-messages-area">
             <ChatMessages messages={messages} />
+          </div>
+          <div className="mobile-chat-input-area">
             <ChatPanel messages={messages} />
           </div>
         </div>
@@ -77,7 +79,7 @@ export function Chat({ id }: ChatProps) {
     <MapDataProvider> {/* Add Provider */}
       <div className="flex justify-start items-start">
         {/* This is the new div for scrolling */}
-        <div className="w-1/2 flex flex-col space-y-3 md:space-y-4 px-8 sm:px-12 pt-12 md:pt-14 pb-4 h-[calc(100vh-10rem)] overflow-y-auto">
+        <div className="w-1/2 flex flex-col space-y-3 md:space-y-4 px-8 sm:px-12 pt-12 md:pt-14 pb-4 h-[calc(100vh-0.5in)] overflow-y-auto">
           <ChatMessages messages={messages} />
           <ChatPanel messages={messages} />
         </div>


### PR DESCRIPTION
### **User description**
The chat area container in the desktop layout was previously shorter than the map container, causing the chat preview to appear cropped at the bottom relative to the map.

This change modifies `components/chat.tsx` to set the height of the desktop chat area (the div wrapping ChatMessages and ChatPanel) from `h-[calc(100vh-10rem)]` to `h-[calc(100vh-0.5in)]`. This makes its height consistent with the map container's height, ensuring both extend to the same vertical position on the screen.


___

### **PR Type**
Enhancement


___

### **Description**
- Align desktop chat area height with map container

- Refactor mobile chat layout into separate message and input areas

- Update CSS classes for improved mobile chat structure


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>globals.css</strong><dd><code>Refactor and enhance mobile chat CSS structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/globals.css

<li>Commented out old <code>.mobile-chat-section</code> CSS.<br> <li> Added <code>.mobile-chat-messages-area</code> and <code>.mobile-chat-input-area</code> classes <br>for mobile chat.<br> <li> Updated styling for better separation of chat messages and input on <br>mobile.


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/167/files#diff-79e0914d9fee5ca4432bdb002a24d700d31b5577265f4de3f90d5c292b9f1392">+24/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chat-panel.tsx</strong><dd><code>Improve mobile ChatPanel height and layout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/chat-panel.tsx

<li>Set mobile ChatPanel to use full height (<code>h-full</code>).<br> <li> Adjusted form layout for mobile to vertically center content.


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/167/files#diff-06a509597829dfc3e720c47b51047e08ba858772f51c5dfd2e01bd6deefb4241">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chat.tsx</strong><dd><code>Update chat layout for mobile and desktop consistency</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/chat.tsx

<li>Replaced <code>.mobile-chat-section</code> with <code>.mobile-chat-messages-area</code> and <br><code>.mobile-chat-input-area</code>.<br> <li> Updated desktop chat area height to <code>h-[calc(100vh-0.5in)]</code> for <br>consistency with map.


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/167/files#diff-015689ed51facf46aa073450a0660cfa8b56e37b6b94248a56ec66550007f31b">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>