### PR TITLE
Refactor: Display only image results in search

### DIFF
--- a/components/search-section.tsx
+++ b/components/search-section.tsx
@@ -30,9 +30,6 @@ export function SearchSection({ result }: SearchSectionProps) {
               />
             </Section>
           )}
-          <Section title="Sources">
-            <SearchResults results={searchResults.results} />
-          </Section>
         </>
       ) : (
         <Section className="pt-2 pb-0">


### PR DESCRIPTION
### **User description**
This commit modifies the `SearchSection` component to exclusively render the `SearchResultsImageSection` when image data is available. The text-based `SearchResults` component has been removed to ensure that only the output with links and images is generated, addressing the issue of duplicate query rendering.


___

### **PR Type**
Enhancement


___

### **Description**
- Remove text-based search results from `SearchSection`

- Display only image results when available

- Prevent duplicate query rendering in search output


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>search-section.tsx</strong><dd><code>Restrict SearchSection to image-only search results</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/search-section.tsx

<li>Removed rendering of text-based <code>SearchResults</code> component<br> <li> Now only renders <code>SearchResultsImageSection</code> for image results<br> <li> Eliminates duplicate query output in search results


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/168/files#diff-493a75a626175d3ec8a6e50266e5d717f5a52876c4864646a414475c929f6656">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>