### PR TITLE
feat: Add Smithery MCP server configuration

### DIFF
--- a/mapbox_mcp_config.json
+++ b/mapbox_mcp_config.json
@@ -1,0 +1,17 @@
+{
+  "mcpServers": {
+    "mapbox-mcp-server": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@smithery/cli@latest",
+        "run",
+        "@ngoiyaeric/mapbox-mcp-server",
+        "--key",
+        "705b0222-a657-4cd2-b180-80c406cf6179",
+        "--profile",
+        "smooth-lemur-vfUbUE"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
### **User description**
This commit introduces the `mapbox_mcp_config.json` file to the project root. This file provides the necessary configuration for the Smithery CLI to run the `@ngoiyaeric/mapbox-mcp-server`.

The configuration specifies the command and arguments required to start the MCP server, facilitating your local development and testing of services that depend on this Mapbox MCP server.


___

### **PR Type**
enhancement, configuration changes


___

### **Description**
- Add `mapbox_mcp_config.json` for Smithery CLI integration

- Configure command and arguments for MCP server startup

- Enable local development with Mapbox MCP server


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mapbox_mcp_config.json</strong><dd><code>Add configuration for Mapbox MCP server via Smithery CLI</code>&nbsp; </dd></summary>
<hr>

mapbox_mcp_config.json

<li>Introduces new configuration file for MCP server<br> <li> Specifies command and arguments for server execution<br> <li> Facilitates local development and testing with Smithery CLI


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/171/files#diff-0f4c9108d094957ac3137c81614f2e25ea68aa4db45089353b213925a06d3491">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>