### PR TITLE
Fix: Ensure chat history preview updates on navigation

### DIFF
--- a/app/search/[id]/page.tsx
+++ b/app/search/[id]/page.tsx
@@ -32,6 +32,7 @@ export default async function SearchPage({ params }: SearchPageProps) {
 
   return (
     <AI
+      key={id}
       initialAIState={{
         chatId: chat.id,
         messages: chat.messages,

--- a/app/search/[id]/page.tsx
+++ b/app/search/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound, redirect } from 'next/navigation';
 import { Chat } from '@/components/chat';
 import { getChat } from '@/lib/actions/chat';
-import { AI } from '@/app/actions';
+import { AI, type AIMessage } from '@/app/actions'; // Ensure AIMessage is imported if it's used by Chat type, or import from lib/types
 
 export const maxDuration = 60;
 
@@ -26,8 +26,26 @@ export default async function SearchPage({ params }: SearchPageProps) {
     redirect('/');
   }
 
-  if (chat?.userId !== userId) {
+  if (chat.userId !== userId) {
     notFound();
+  }
+
+  let parsedMessages: AIMessage[];
+
+  // Check if chat.messages exists and is a string before trying to parse
+  if (chat.messages && typeof chat.messages === 'string') {
+    try {
+      parsedMessages = JSON.parse(chat.messages);
+    } catch (error) {
+      console.error('Failed to parse chat.messages from string:', error);
+      parsedMessages = []; // Fallback to empty array on error
+    }
+  } else if (Array.isArray(chat.messages)) {
+    parsedMessages = chat.messages; // Assume it's already an array
+  } else {
+    // Handle cases where chat.messages is neither a string nor an array (e.g., null, undefined)
+    console.warn('chat.messages is not a string or array, defaulting to empty array.');
+    parsedMessages = [];
   }
 
   return (
@@ -35,7 +53,7 @@ export default async function SearchPage({ params }: SearchPageProps) {
       key={id}
       initialAIState={{
         chatId: chat.id,
-        messages: chat.messages,
+        messages: parsedMessages, // Use the correctly typed parsedMessages
       }}
     >
       <Chat id={id} />

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -79,6 +79,7 @@ export function Chat({ id }: ChatProps) {
                 submitMessage={message => {
                   setInput(message)
                 }}
++                isEmptyHistory={!!id}
               />
             ) : (
               <ChatMessages messages={messages} />

--- a/components/empty-screen.tsx
+++ b/components/empty-screen.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@/components/ui/button';
-import { TreePine, Sun ,Rocket, Moon} from 'lucide-react';
+import { TreePine, Sun, Rocket, Moon, Info } from 'lucide-react'; // Added Info
 
 const exampleMessages = [
   {
@@ -24,35 +24,48 @@ const exampleMessages = [
   },
 ];
 
+interface EmptyScreenProps {
+  submitMessage: (message: string) => void;
+  className?: string;
+  isEmptyHistory?: boolean; // New prop
+}
+
 export function EmptyScreen({
   submitMessage,
   className,
-}: {
-  submitMessage: (message: string) => void;
-  className?: string;
-}) {
+  isEmptyHistory, // Destructure new prop
+}: EmptyScreenProps) {
   return (
     <div className={`mx-auto w-full transition-all ${className}`}>
       <div className="bg-background p-2">
-        <div className="mt-4 flex flex-col items-start space-y-2 mb-4">
-          {exampleMessages.map((item) => {
-            const Icon = item.icon;
-            return (
-              <Button
-                key={item.message} // Use a unique property as the key.
-                variant="link"
-                className="h-auto p-0 text-base flex items-center"
-                name={item.message}
-                onClick={async () => {
-                  submitMessage(item.message);
-                }}
-              >
-                <Icon size={16} className="mr-2 text-muted-foreground" />
-                {item.heading}
-              </Button>
-            );
-          })}
-        </div>
+        {isEmptyHistory ? (
+          <div className="mt-4 flex flex-col items-center justify-center text-center space-y-2 mb-4 p-4">
+            <Info size={24} className="text-muted-foreground" />
+            <p className="text-muted-foreground">
+              No messages found in this conversation.
+            </p>
+          </div>
+        ) : (
+          <div className="mt-4 flex flex-col items-start space-y-2 mb-4">
+            {exampleMessages.map((item) => {
+              const Icon = item.icon;
+              return (
+                <Button
+                  key={item.message}
+                  variant="link"
+                  className="h-auto p-0 text-base flex items-center"
+                  name={item.message}
+                  onClick={async () => {
+                    submitMessage(item.message);
+                  }}
+                >
+                  <Icon size={16} className="mr-2 text-muted-foreground" />
+                  {item.heading}
+                </Button>
+              );
+            })}
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
### **User description**
The chat history preview was not updating to show the messages of the selected historical chat, particularly noted on mobile. This was due to the AI state (managed by the `AI` provider component) not being re-initialized when navigating to a different chat ID.

This commit fixes the issue by adding a `key` prop, set to the chat `id`, to the `AI` component in `app/search/[id]/page.tsx`. This ensures that the `AI` provider and its associated state (including `useUIState` and `useAIState` hooks) are fully re-mounted and re-initialized whenever the chat `id` changes due to navigation. This results in the correct chat messages being loaded and displayed in the `ChatMessages` component.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes chat history preview not updating on navigation

- Ensures AI provider re-initializes when chat ID changes

- Resolves issue with stale messages shown in chat preview


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Add key prop to AI component for state reset on navigation</code></dd></summary>
<hr>

app/search/[id]/page.tsx

<li>Adds a <code>key</code> prop set to <code>id</code> on the <code>AI</code> component<br> <li> Forces remount and re-initialization of AI state on chat ID change


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/178/files#diff-1f9ad75b8bbbe1fb55b25542b6b2624aa1c0a4b51a9ca7b1da54f141d5aed657">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>