### PR TITLE
Fix: Ensure Mapbox loading Lottie only renders on initial app start

### DIFF
--- a/components/conditional-lottie.tsx
+++ b/components/conditional-lottie.tsx
@@ -4,8 +4,8 @@ import LottiePlayer from '@/components/ui/lottie-player';
 import { useMapLoading } from '@/components/map-loading-context';
 
 const ConditionalLottie = () => {
-  const { isMapLoaded } = useMapLoading();
-  return <LottiePlayer isVisible={!isMapLoaded} />;
+  const { isMapLoaded, hasAppInitiallyLoaded } = useMapLoading();
+  return <LottiePlayer isVisible={!isMapLoaded && !hasAppInitiallyLoaded} />;
 };
 
 export default ConditionalLottie;

--- a/components/map-loading-context.tsx
+++ b/components/map-loading-context.tsx
@@ -4,14 +4,28 @@ import { createContext, useContext, useState, ReactNode } from 'react';
 interface MapLoadingContextType {
   isMapLoaded: boolean;
   setIsMapLoaded: (isLoaded: boolean) => void;
+  hasAppInitiallyLoaded: boolean;
 }
 
 const MapLoadingContext = createContext<MapLoadingContextType | undefined>(undefined);
 
 export const MapLoadingProvider = ({ children }: { children: ReactNode }) => {
-  const [isMapLoaded, setIsMapLoaded] = useState(false);
+  const [isMapLoaded, setIsMapLoadedState] = useState(false);
+  const [hasAppInitiallyLoaded, setHasAppInitiallyLoaded] = useState(false);
+
+  const setIsMapLoaded = (isLoaded: boolean) => {
+    if (isLoaded && !hasAppInitiallyLoaded) {
+      setIsMapLoadedState(true);
+      setHasAppInitiallyLoaded(true);
+    } else if (hasAppInitiallyLoaded) {
+      setIsMapLoadedState(true); // Keep isMapLoaded true if app has initially loaded
+    } else {
+      setIsMapLoadedState(isLoaded);
+    }
+  };
+
   return (
-    <MapLoadingContext.Provider value={{ isMapLoaded, setIsMapLoaded }}>
+    <MapLoadingContext.Provider value={{ isMapLoaded, setIsMapLoaded, hasAppInitiallyLoaded }}>
       {children}
     </MapLoadingContext.Provider>
   );

--- a/components/map/mapbox-map.tsx
+++ b/components/map/mapbox-map.tsx
@@ -33,7 +33,7 @@ export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number
   const drawingFeatures = useRef<any>(null)
   const { mapType } = useMapToggle()
   const { mapData } = useMapData(); // Consume the new context
-  const { setIsMapLoaded } = useMapLoading(); // Get setIsMapLoaded from context
+  const { setIsMapLoaded, hasAppInitiallyLoaded } = useMapLoading(); // Get setIsMapLoaded and hasAppInitiallyLoaded from context
   const previousMapTypeRef = useRef<MapToggleEnum | null>(null)
   // const [isMapLoaded, setIsMapLoaded] = useState(false); // Removed local state
 
@@ -450,7 +450,9 @@ export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number
         Object.values(lineLabelsRef.current).forEach(marker => marker.remove())
         
         stopRotation()
-        setIsMapLoaded(false) // Reset map loaded state on cleanup
+        if (!hasAppInitiallyLoaded) {
+          setIsMapLoaded(false); // Reset map loaded state on cleanup only if not initially loaded
+        }
         map.current.remove()
         map.current = null
       }
@@ -469,7 +471,8 @@ export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number
     setupGeolocationWatcher, 
     captureMapCenter, 
     setupDrawingTools,
-    setIsMapLoaded // Added missing dependency
+    setIsMapLoaded, // Added missing dependency
+    hasAppInitiallyLoaded // Added hasAppInitiallyLoaded to dependency array
   ])
 
   // Handle position updates from props


### PR DESCRIPTION
### **User description**
The Lottie animation intended for Mapbox loading was incorrectly rendering during navigations to other pages (e.g., Settings) after the initial application load.

This was caused by the `isMapLoaded` state being reset when the Mapbox component unmounted during page transitions.

The fix involves the following changes:

1.  Modified `map-loading-context.tsx`:
    - Introduced a new state variable `hasAppInitiallyLoaded` to track if the application has completed its first map load.
    - `isMapLoaded` is now preserved as `true` once `hasAppInitiallyLoaded` becomes `true`, preventing it from being reset on subsequent unmounts.

2.  Updated `mapbox-map.tsx`:
    - The cleanup function in the main map initialization `useEffect` now conditionally calls `setIsMapLoaded(false)` only if `hasAppInitiallyLoaded` is `false`. This prevents resetting the loading state after the initial load.

3.  Refined `ConditionalLottie.tsx`:
    - The Lottie animation is now rendered only if `!isMapLoaded` AND `!hasAppInitiallyLoaded`. This ensures it's strictly shown only during the very first application startup sequence before the map is ready.

These changes ensure the loading animation provides the correct user experience by only appearing when the application is genuinely performing its initial load.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Restricts Mapbox loading Lottie animation to initial app load only
  - Adds `hasAppInitiallyLoaded` state to track first map load
  - Updates context and logic to prevent animation on subsequent navigations

- Refines map loading state cleanup to avoid resetting after initial load

- Updates Lottie animation visibility logic for correct user experience


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>conditional-lottie.tsx</strong><dd><code>Restrict Lottie animation to initial map load</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/conditional-lottie.tsx

<li>Uses both <code>isMapLoaded</code> and new <code>hasAppInitiallyLoaded</code> to control Lottie <br>visibility<br> <li> Ensures Lottie animation only appears before first map load completes


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/180/files#diff-00996be832e3f4c3c54d475b846e259f6156688cc57738c9f7ec83c87ab3fdb1">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>map-loading-context.tsx</strong><dd><code>Add and manage initial map load state in context</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/map-loading-context.tsx

<li>Adds <code>hasAppInitiallyLoaded</code> state to context<br> <li> Updates <code>setIsMapLoaded</code> to set and preserve initial load state<br> <li> Provides new state in context value


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/180/files#diff-14fcf329eba06300c4123a022af6a9d2cb6b50bbae0c97de0f7f8081e9384573">+16/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mapbox-map.tsx</strong><dd><code>Refine map loading cleanup based on initial load state</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/map/mapbox-map.tsx

<li>Consumes new <code>hasAppInitiallyLoaded</code> from context<br> <li> Cleans up map loading state only if app not initially loaded<br> <li> Updates effect dependencies for new state


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/180/files#diff-ce7ea3ef85a6812c7da39941ffa47e8e0fadbb3fc7c391cf1cafd96303cf3a0f">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>