### PR TITLE
Fix: Prevent Lottie loader from blocking settings page

### DIFF
--- a/components/conditional-lottie.tsx
+++ b/components/conditional-lottie.tsx
@@ -2,10 +2,14 @@
 
 import LottiePlayer from '@/components/ui/lottie-player';
 import { useMapLoading } from '@/components/map-loading-context';
+import { useProfileToggle } from '@/components/profile-toggle-context'; // Added import
 
 const ConditionalLottie = () => {
   const { isMapLoaded } = useMapLoading();
-  return <LottiePlayer isVisible={!isMapLoaded} />;
+  const { activeView } = useProfileToggle(); // Added this line
+
+  // Updated isVisible logic
+  return <LottiePlayer isVisible={!isMapLoaded && activeView === null} />;
 };
 
 export default ConditionalLottie;


### PR DESCRIPTION
### **User description**
The full-screen Lottie animation, intended to show during map loading, was also displayed when profile sections (including Settings, Account, Appearance, and Security) were active. This blocked interaction with these sections.

The `ConditionalLottie` component has been updated to check if any profile section is currently active via the `useProfileToggle` context. The Lottie animation will now only be visible if the map is loading AND no profile section is open. This ensures that your settings and other profile views are always accessible without being obscured by the loader, while still showing the loader during map initialization on relevant pages.


___

### **PR Type**
Bug fix


___

### **Description**
• Fixed Lottie loader blocking profile sections (Settings, Account, etc.)
• Added profile context check to conditional rendering logic
• Loader now only shows when map loading AND no profile section active


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>conditional-lottie.tsx</strong><dd><code>Enhanced loader visibility logic with profile context</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/conditional-lottie.tsx

• Added <code>useProfileToggle</code> context import<br> • Updated visibility logic to <br>check <code>activeView</code> state<br> • Loader now hidden when profile sections are <br>open


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/185/files#diff-00996be832e3f4c3c54d475b846e259f6156688cc57738c9f7ec83c87ab3fdb1">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>