### PR TITLE
feat: Implement dynamic system prompt functionality

### DIFF
--- a/components/settings/components/settings.tsx
+++ b/components/settings/components/settings.tsx
@@ -16,6 +16,7 @@ import { ModelSelectionForm } from "./model-selection-form"
 import { UserManagementForm } from './user-management-form';
 import { Form } from "@/components/ui/form"
 import { useToast } from "@/components/ui/hooks/use-toast"
+import { getSystemPrompt, saveSystemPrompt } from "lib/actions/chat" // Added import
 
 // Define the form schema
 const settingsFormSchema = z.object({
@@ -68,20 +69,38 @@ export function Settings({ initialTab = "system-prompt" }: SettingsProps) {
     setCurrentTab(initialTab);
   }, [initialTab]);
 
+  // TODO: Replace 'anonymous' with actual user ID from session/auth context
+  const userId = 'anonymous';
+
   const form = useForm<SettingsFormValues>({
     resolver: zodResolver(settingsFormSchema),
     defaultValues,
   })
 
+  useEffect(() => {
+    async function fetchPrompt() {
+      const existingPrompt = await getSystemPrompt(userId);
+      if (existingPrompt) {
+        form.setValue("systemPrompt", existingPrompt, { shouldValidate: true, shouldDirty: false });
+      }
+    }
+    fetchPrompt();
+  }, [form, userId]);
+
   async function onSubmit(data: SettingsFormValues) {
     setIsLoading(true)
 
     try {
-      // Simulate API call
-      await new Promise((resolve) => setTimeout(resolve, 1000))
+      // Save the system prompt
+      const saveResult = await saveSystemPrompt(userId, data.systemPrompt);
 
-      // Use the data parameter to avoid unused variable error
-      console.log("Submitted data:", data)
+      if (saveResult?.error) {
+        throw new Error(saveResult.error);
+      }
+
+      // Simulate other API calls if necessary or remove if only saving system prompt for this form
+      await new Promise((resolve) => setTimeout(resolve, 200)) // Shorter delay now
+      console.log("Submitted data (including system prompt):", data)
 
       // Success notification
       toast({
@@ -90,12 +109,12 @@ export function Settings({ initialTab = "system-prompt" }: SettingsProps) {
       })
 
       // Refresh the page to reflect changes
-      router.refresh()
-    } catch (error) {
+      // router.refresh(); // Consider if refresh is needed or if optimistic update is enough
+    } catch (error: any) {
       // Error notification
       toast({
         title: "Something went wrong",
-        description: "Your settings could not be saved. Please try again.",
+        description: error.message || "Your settings could not be saved. Please try again.",
         variant: "destructive",
       })
     } finally {

--- a/components/settings/components/settings.tsx
+++ b/components/settings/components/settings.tsx
@@ -16,7 +16,7 @@ import { ModelSelectionForm } from "./model-selection-form"
 import { UserManagementForm } from './user-management-form';
 import { Form } from "@/components/ui/form"
 import { useToast } from "@/components/ui/hooks/use-toast"
-import { getSystemPrompt, saveSystemPrompt } from "lib/actions/chat" // Added import
+import { getSystemPrompt, saveSystemPrompt } from "../../../lib/actions/chat" // Added import
 
 // Define the form schema
 const settingsFormSchema = z.object({

--- a/lib/actions/chat.ts
+++ b/lib/actions/chat.ts
@@ -147,3 +147,41 @@ export async function updateDrawingContext(chatId: string, drawnFeatures: any[])
     return { error: 'Failed to save updated chat' };
   }
 }
+
+export async function saveSystemPrompt(
+  userId: string,
+  prompt: string
+): Promise<{ success?: boolean; error?: string }> {
+  if (!userId) {
+    return { error: 'User ID is required' }
+  }
+
+  if (!prompt) {
+    return { error: 'Prompt is required' }
+  }
+
+  try {
+    await redis.set(`system_prompt:${userId}`, prompt)
+    return { success: true }
+  } catch (error) {
+    console.error('saveSystemPrompt: Error saving system prompt:', error)
+    return { error: 'Failed to save system prompt' }
+  }
+}
+
+export async function getSystemPrompt(
+  userId: string
+): Promise<string | null> {
+  if (!userId) {
+    console.error('getSystemPrompt: User ID is required')
+    return null
+  }
+
+  try {
+    const prompt = await redis.get<string>(`system_prompt:${userId}`)
+    return prompt
+  } catch (error) {
+    console.error('getSystemPrompt: Error retrieving system prompt:', error)
+    return null
+  }
+}

--- a/lib/agents/researcher.tsx
+++ b/lib/agents/researcher.tsx
@@ -12,6 +12,7 @@ import { getTools } from './tools'
 import { getModel } from '../utils'
 
 export async function researcher(
+  dynamicSystemPrompt: string, // New parameter
   uiStream: ReturnType<typeof createStreamableUI>,
   streamText: ReturnType<typeof createStreamableValue<string>>,
   messages: CoreMessage[],
@@ -26,7 +27,8 @@ export async function researcher(
   )
 
   const currentDate = new Date().toLocaleString()
-  const system_prompt = `As a comprehensive AI assistant, you can search the web, retrieve information from URLs, and understand geospatial queries to assist the user and display information on a map.
+  // Default system prompt, used if dynamicSystemPrompt is not provided
+  const default_system_prompt = `As a comprehensive AI assistant, you can search the web, retrieve information from URLs, and understand geospatial queries to assist the user and display information on a map.
 Current date and time: ${currentDate}.
 
 Tool Usage Guide:
@@ -43,10 +45,12 @@ Tool Usage Guide:
 Always aim to directly address the user's question. If using information from a tool (like web search), cite the source URL.
 Match the language of your response to the user's language.`;
 
+     const systemToUse = dynamicSystemPrompt && dynamicSystemPrompt.trim() !== '' ? dynamicSystemPrompt : default_system_prompt;
+
      const result = await nonexperimental_streamText({
        model: getModel() as LanguageModel,
        maxTokens: 2500,
-       system: system_prompt, // Use the updated prompt
+       system: systemToUse, // Use the dynamic or default system prompt
        messages,
        tools: getTools({
       uiStream,

--- a/lib/agents/writer.tsx
+++ b/lib/agents/writer.tsx
@@ -5,6 +5,7 @@ import { BotMessage } from '@/components/message'
 import { getModel } from '../utils'
 
 export async function writer(
+  dynamicSystemPrompt: string, // New parameter
   uiStream: ReturnType<typeof createStreamableUI>,
   streamText: ReturnType<typeof createStreamableValue<string>>,
   messages: CoreMessage[]
@@ -17,15 +18,20 @@ export async function writer(
   )
   uiStream.append(answerSection)
 
-  const result = await nonexperimental_streamText({
-    model: getModel() as LanguageModel,
-    maxTokens: 2500,
-    system: `As a professional writer, your job is to generate a comprehensive and informative, yet concise answer of 400 words or less for the given question based solely on the provided search results (URL and content). You must only use information from the provided search results. Use an unbiased and journalistic tone. Combine search results together into a coherent answer. Do not repeat text. If there are any images relevant to your answer, be sure to include them as well. Aim to directly address the user's question, augmenting your response with insights gleaned from the search results. 
+  // Default system prompt, used if dynamicSystemPrompt is not provided
+  const default_system_prompt = `As a professional writer, your job is to generate a comprehensive and informative, yet concise answer of 400 words or less for the given question based solely on the provided search results (URL and content). You must only use information from the provided search results. Use an unbiased and journalistic tone. Combine search results together into a coherent answer. Do not repeat text. If there are any images relevant to your answer, be sure to include them as well. Aim to directly address the user's question, augmenting your response with insights gleaned from the search results.
     Whenever quoting or referencing information from a specific URL, always cite the source URL explicitly. Please match the language of the response to the user's language.
     Always answer in Markdown format. Links and images must follow the correct format.
     Link format: [link text](url)
     Image format: ![alt text](url)
-    `,
+    `;
+
+  const systemToUse = dynamicSystemPrompt && dynamicSystemPrompt.trim() !== '' ? dynamicSystemPrompt : default_system_prompt;
+
+  const result = await nonexperimental_streamText({
+    model: getModel() as LanguageModel,
+    maxTokens: 2500,
+    system: systemToUse, // Use the dynamic or default system prompt
     messages
   })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "@tailwindcss/typography": "^0.5.16",
         "@turf/turf": "^7.2.0",
         "@types/mapbox__mapbox-gl-draw": "^1.4.8",
-        "@upstash/redis": "^1.34.8",
+        "@upstash/redis": "^1.35.0",
         "ai": "^4.3.16",
         "build": "^0.1.4",
         "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@tailwindcss/typography": "^0.5.16",
     "@turf/turf": "^7.2.0",
     "@types/mapbox__mapbox-gl-draw": "^1.4.8",
-    "@upstash/redis": "^1.34.8",
+    "@upstash/redis": "^1.35.0",
     "ai": "^4.3.16",
     "build": "^0.1.4",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
### **User description**
This commit introduces the ability for you to set a system prompt via the settings interface, which then influences the behavior of my chat responses.

Key changes include:

- Added `getSystemPrompt` and `saveSystemPrompt` actions in `lib/actions/chat.ts` to store and retrieve system prompts from Redis, keyed by userId (currently using a placeholder).
- Updated the settings UI (`components/settings/components/settings.tsx`) to allow you to input and save a system prompt. The form now loads the saved prompt on mount.
- Modified the main chat action (`app/actions.tsx`) to fetch your current system prompt and pass it to me.
- I've been adapted to accept this dynamic system prompt. If a dynamic prompt is provided and not empty, I'll use it as my system message; otherwise, I'll use a default system prompt.

Further work:
- Replace placeholder user IDs with actual user identification for multi-user support.
- Thorough manual testing is recommended to ensure my chat responses accurately reflect the configured system prompt.


___

### **PR Type**
Enhancement


___

### **Description**
• Add dynamic system prompt functionality with Redis storage
• Enable users to configure custom system prompts via settings UI
• Integrate system prompt retrieval into chat agents
• Update dependencies and add proper error handling


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chat.ts</strong><dd><code>Add Redis-based system prompt storage functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/actions/chat.ts

• Add <code>saveSystemPrompt</code> function to store user prompts in Redis<br> • Add <br><code>getSystemPrompt</code> function to retrieve stored prompts<br> • Include error <br>handling and validation for user ID and prompt requirements


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/189/files#diff-819d2d9016d052cd621d2190deaf60688a87f953233d709b40fdabcf99d83f47">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>actions.tsx</strong><dd><code>Integrate system prompt retrieval into chat flow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/actions.tsx

• Import <code>getSystemPrompt</code> function from chat actions<br> • Fetch current <br>system prompt for anonymous user<br> • Pass system prompt to researcher <br>and writer agents<br> • Add TODO comments for future user authentication <br>integration


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/189/files#diff-5d789135759f172b94f5f9b4c62ad9f1410b79f4c8cff86ffed6464f22b61752">+10/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>settings.tsx</strong><dd><code>Add system prompt management to settings UI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/settings/components/settings.tsx

• Import system prompt functions from chat actions<br> • Add useEffect to <br>load existing system prompt on component mount<br> • Update form <br>submission to save system prompt via API<br> • Improve error handling with <br>specific error messages


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/189/files#diff-e5e581726a6654a538e3bf0b9fd9e4f51d34c6b1e1a2c1437b871877ffde1e34">+26/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>researcher.tsx</strong><dd><code>Support dynamic system prompts in researcher agent</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/agents/researcher.tsx

• Add <code>dynamicSystemPrompt</code> parameter to researcher function<br> • Implement <br>logic to use dynamic prompt or fallback to default<br> • Rename system <br>prompt variable for clarity


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/189/files#diff-07a588855c7c4f7ac8f731bb6b4876aa2fa6e9fda6096e999d0c131a3444a251">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>writer.tsx</strong><dd><code>Support dynamic system prompts in writer agent</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/agents/writer.tsx

• Add <code>dynamicSystemPrompt</code> parameter to writer function<br> • Implement <br>conditional system prompt selection logic<br> • Extract default system <br>prompt to separate variable


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/189/files#diff-697b43e11799e4e593200f692292a59deb889a062e623e831563b73630515535">+11/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Update Redis dependency version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

• Update `@upstash/redis` dependency from version 1.34.8 to 1.35.0


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/189/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>