### PR TITLE
Fix: Resolve React Hook usage error in getTools

### DIFF
--- a/app/actions.tsx
+++ b/app/actions.tsx
@@ -12,6 +12,7 @@ import { Spinner } from '@/components/ui/spinner';
 import { Section } from '@/components/section';
 import { FollowupPanel } from '@/components/followup-panel';
 import { inquire, researcher, taskManager, querySuggestor } from '@/lib/agents';
+import { useGeospatialToolMcp } from '@/lib/agents/tools/geospatial'; // Added import for the hook
 import { writer } from '@/lib/agents/writer';
 import { saveChat, getSystemPrompt } from '@/lib/actions/chat'; // Added getSystemPrompt
 import { Chat, AIMessage } from '@/lib/types';
@@ -29,7 +30,7 @@ type RelatedQueries = {
   items: { query: string }[];
 };
 
-async function submit(formData?: FormData, skip?: boolean) {
+async function submit(formData?: FormData, skip?: boolean, mcp?: any) { // Added mcp as a parameter
 'use server';
 
   // TODO: Update agent function signatures in lib/agents/researcher.tsx and lib/agents/writer.tsx
@@ -145,6 +146,7 @@ async function submit(formData?: FormData, skip?: boolean) {
         uiStream,
         streamText,
         messages,
+        mcp, // Pass mcp to researcher
         useSpecificAPI
       );
       answer = fullResponse;

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useRef } from 'react'
 import { useRouter } from 'next/navigation'
 import type { AI, UIState } from '@/app/actions'
 import { useUIState, useActions } from 'ai/rsc'
+import { useGeospatialToolMcp } from '@/lib/agents/tools/geospatial' // Added import
 import { cn } from '@/lib/utils'
 import { UserMessage } from './user-message'
 import { Button } from './ui/button'
@@ -20,6 +21,7 @@ interface ChatPanelProps {
 export function ChatPanel({ messages, input, setInput }: ChatPanelProps) {
   const [, setMessages] = useUIState<typeof AI>()
   const { submit } = useActions()
+  const mcp = useGeospatialToolMcp() // Call the hook
   const [isButtonPressed, setIsButtonPressed] = useState(false)
   const [isMobile, setIsMobile] = useState(false)
   const inputRef = useRef<HTMLTextAreaElement>(null)
@@ -56,7 +58,7 @@ export function ChatPanel({ messages, input, setInput }: ChatPanelProps) {
       }
     ])
     const formData = new FormData(e.currentTarget)
-    const responseMessage = await submit(formData)
+    const responseMessage = await submit(formData, undefined, mcp) // Pass mcp
     setMessages(currentMessages => [...currentMessages, responseMessage as any])
   }
 

--- a/components/copilot.tsx
+++ b/components/copilot.tsx
@@ -8,9 +8,9 @@ import { Button } from './ui/button'
 import { Card } from './ui/card'
 import { ArrowRight, Check, FastForward, Sparkles } from 'lucide-react'
 import { useActions, useStreamableValue, useUIState } from 'ai/rsc'
+import { useGeospatialToolMcp } from '@/lib/agents/tools/geospatial' // Added import
 import type { AI } from '@/app/actions'
-import { 
-  
+import {
 
   
  } from './ui/icons'
@@ -32,6 +32,7 @@ export const Copilot: React.FC<CopilotProps> = ({ inquiry }: CopilotProps) => {
   const [isButtonDisabled, setIsButtonDisabled] = useState(true)
   const [, setMessages] = useUIState<typeof AI>()
   const { submit } = useActions()
+  const mcp = useGeospatialToolMcp() // Call the hook
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setQuery(event.target.value)
@@ -78,7 +79,7 @@ export const Copilot: React.FC<CopilotProps> = ({ inquiry }: CopilotProps) => {
       ? undefined
       : new FormData(e.target as HTMLFormElement)
 
-    const response = await submit(formData, skip)
+    const response = await submit(formData, skip, mcp) // Pass mcp
     setMessages(currentMessages => [...currentMessages, response])
   }
 

--- a/components/followup-panel.tsx
+++ b/components/followup-panel.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { Button } from './ui/button'
 import { Input } from './ui/input'
 import { useActions, useUIState } from 'ai/rsc'
+import { useGeospatialToolMcp } from '@/lib/agents/tools/geospatial' // Added import
 import type { AI } from '@/app/actions'
 import { UserMessage } from './user-message'
 import { ArrowRight } from 'lucide-react'
@@ -11,6 +12,7 @@ import { ArrowRight } from 'lucide-react'
 export function FollowupPanel() {
   const [input, setInput] = useState('')
   const { submit } = useActions()
+  const mcp = useGeospatialToolMcp() // Call the hook
   const [, setMessages] = useUIState<typeof AI>()
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
@@ -23,7 +25,7 @@ export function FollowupPanel() {
       component: <UserMessage message={input} />
     }
 
-    const responseMessage = await submit(formData)
+    const responseMessage = await submit(formData, undefined, mcp) // Pass mcp
     setMessages(currentMessages => [
       ...currentMessages,
       userMessage,

--- a/components/search-related.tsx
+++ b/components/search-related.tsx
@@ -11,6 +11,7 @@ import {
   StreamableValue
 } from 'ai/rsc'
 import { AI } from '@/app/actions'
+import { useGeospatialToolMcp } from '@/lib/agents/tools/geospatial' // Added import
 import { UserMessage } from './user-message'
 import { PartialRelated } from '@/lib/schema/related'
 
@@ -22,6 +23,7 @@ export const SearchRelated: React.FC<SearchRelatedProps> = ({
   relatedQueries
 }) => {
   const { submit } = useActions()
+  const mcp = useGeospatialToolMcp() // Call the hook
   const [, setMessages] = useUIState<typeof AI>()
   const [data, error, pending] =
     useStreamableValue<PartialRelated>(relatedQueries)
@@ -44,7 +46,7 @@ export const SearchRelated: React.FC<SearchRelatedProps> = ({
       component: <UserMessage message={query} />
     }
 
-    const responseMessage = await submit(formData)
+    const responseMessage = await submit(formData, undefined, mcp) // Pass mcp
     setMessages(currentMessages => [
       ...currentMessages,
       userMessage,

--- a/lib/agents/researcher.tsx
+++ b/lib/agents/researcher.tsx
@@ -16,6 +16,7 @@ export async function researcher(
   uiStream: ReturnType<typeof createStreamableUI>,
   streamText: ReturnType<typeof createStreamableValue<string>>,
   messages: CoreMessage[],
+  mcp: any, // Moved mcp before optional parameter
   useSpecificModel?: boolean
 ) {
   let fullResponse = ''
@@ -54,7 +55,8 @@ Match the language of your response to the user's language.`;
        messages,
        tools: getTools({
       uiStream,
-      fullResponse
+      fullResponse,
+      mcp // Pass the mcp parameter to getTools
     })
   })
 

--- a/lib/agents/tools/geospatial.tsx
+++ b/lib/agents/tools/geospatial.tsx
@@ -1,4 +1,4 @@
-import { createStreamableValue } from 'ai/rsc';
+import { createStreamableValue } from 'ai/rsc'; // Ensuring this is the original path
 import { useMcp } from 'use-mcp/react';
 import { BotMessage } from '@/components/message';
 import { geospatialQuerySchema } from '@/lib/schema/geospatial';

--- a/lib/agents/tools/index.tsx
+++ b/lib/agents/tools/index.tsx
@@ -7,9 +7,10 @@ import { geospatialTool, useGeospatialToolMcp } from './geospatial'; // Added im
 export interface ToolProps {
   uiStream: ReturnType<typeof createStreamableUI>
   fullResponse: string
+  mcp?: any // Made mcp optional
 }
 
-export const getTools = ({ uiStream, fullResponse }: ToolProps) => {
+export const getTools = ({ uiStream, fullResponse, mcp }: ToolProps) => {
   const tools: any = {
     search: searchTool({
       uiStream,
@@ -23,7 +24,7 @@ export const getTools = ({ uiStream, fullResponse }: ToolProps) => {
      geospatialQueryTool: geospatialTool({ 
        uiStream,
        fullResponse,
-       mcp: useGeospatialToolMcp()
+       mcp // Use the passed mcp
      })
   }
 
@@ -36,19 +37,3 @@ export const getTools = ({ uiStream, fullResponse }: ToolProps) => {
 
   return tools
 }
-
-export const useTools = ({ uiStream, fullResponse }: ToolProps) => {
-  const mcp = useGeospatialToolMcp();
-
-  const tools: any = {
-    search: searchTool({ uiStream, fullResponse }),
-    retrieve: retrieveTool({ uiStream, fullResponse }),
-    geospatialQueryTool: geospatialTool({ uiStream, fullResponse, mcp }),
-  };
-
-  if (process.env.SERPER_API_KEY) {
-    tools.videoSearch = videoSearchTool({ uiStream, fullResponse });
-  }
-
-  return tools;
-};


### PR DESCRIPTION
Refactored the `getTools` function and its callers to correctly handle the `useGeospatialToolMcp` hook, preventing it from being called in a non-React component context.

- Modified `getTools` to accept `mcp` as a parameter.
- Updated `researcher` function to accept and pass `mcp`.
- Updated components calling the `submit` action to fetch `mcp` using the hook and pass it down.
- Made `mcp` optional in `ToolProps` as not all tools require it.

The build still fails due to an unresolved import for `createStreamableValue` when its usage is included, and a missing `DATABASE_URL` (which is being disregarded per user instruction). The primary React Hook linting error is resolved.