### PR TITLE
I am adding a loading animation to the logo.

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,7 +10,7 @@ import { Toaster } from '@/components/ui/sonner'
 import { MapToggleProvider } from '@/components/map-toggle-context'
 import { ProfileToggleProvider } from '@/components/profile-toggle-context'
 import { MapLoadingProvider } from '@/components/map-loading-context';
-import ConditionalLottie from '@/components/conditional-lottie';
+import LoadingSpinner from '@/components/loading-spinner';
 
 const fontSans = FontSans({
   subsets: ['latin'],
@@ -63,7 +63,7 @@ export default function RootLayout({
             >
               <MapLoadingProvider>
                 <Header />
-                <ConditionalLottie />
+                <LoadingSpinner />
                 {children}
                 <Sidebar />
                 <Footer />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,6 +10,7 @@ import { Toaster } from '@/components/ui/sonner'
 import { MapToggleProvider } from '@/components/map-toggle-context'
 import { ProfileToggleProvider } from '@/components/profile-toggle-context'
 import { MapLoadingProvider } from '@/components/map-loading-context';
+import { ChatLoadingProvider } from '@/components/chat-loading-context';
 import LoadingSpinner from '@/components/loading-spinner';
 
 const fontSans = FontSans({
@@ -62,12 +63,14 @@ export default function RootLayout({
               themes={['light', 'dark', 'earth']}
             >
               <MapLoadingProvider>
-                <Header />
-                <LoadingSpinner />
-                {children}
-                <Sidebar />
-                <Footer />
-                <Toaster />
+                <ChatLoadingProvider>
+                  <Header />
+                  <LoadingSpinner />
+                  {children}
+                  <Sidebar />
+                  <Footer />
+                  <Toaster />
+                </ChatLoadingProvider>
               </MapLoadingProvider>
             </ThemeProvider>
           </ProfileToggleProvider>

--- a/app/loading.css
+++ b/app/loading.css
@@ -1,0 +1,38 @@
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes fadeOut {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+.spinning {
+  animation: spin 1s linear infinite;
+}
+
+.fade-in {
+  animation: fadeIn 0.5s ease-in-out;
+}
+
+.fade-out {
+  animation: fadeOut 0.5s ease-in-out;
+}

--- a/components/chat-loading-context.tsx
+++ b/components/chat-loading-context.tsx
@@ -1,0 +1,26 @@
+'use client';
+import { createContext, useContext, useState, ReactNode } from 'react';
+
+interface ChatLoadingContextType {
+  isChatLoading: boolean;
+  setIsChatLoading: (isLoading: boolean) => void;
+}
+
+const ChatLoadingContext = createContext<ChatLoadingContextType | undefined>(undefined);
+
+export const ChatLoadingProvider = ({ children }: { children: ReactNode }) => {
+  const [isChatLoading, setIsChatLoading] = useState(false);
+  return (
+    <ChatLoadingContext.Provider value={{ isChatLoading, setIsChatLoading }}>
+      {children}
+    </ChatLoadingContext.Provider>
+  );
+};
+
+export const useChatLoading = () => {
+  const context = useContext(ChatLoadingContext);
+  if (context === undefined) {
+    throw new Error('useChatLoading must be used within a ChatLoadingProvider');
+  }
+  return context;
+};

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useRef } from 'react'
 import { useRouter } from 'next/navigation'
 import type { AI, UIState } from '@/app/actions'
 import { useUIState, useActions } from 'ai/rsc'
+import { useChatLoading } from '@/components/chat-loading-context'
 // Removed import of useGeospatialToolMcp as it's no longer used/available
 import { cn } from '@/lib/utils'
 import { UserMessage } from './user-message'
@@ -21,6 +22,7 @@ interface ChatPanelProps {
 export function ChatPanel({ messages, input, setInput }: ChatPanelProps) {
   const [, setMessages] = useUIState<typeof AI>()
   const { submit } = useActions()
+  const { setIsChatLoading } = useChatLoading()
   // Removed mcp instance as it's no longer passed to submit
   const [isButtonPressed, setIsButtonPressed] = useState(false)
   const [isMobile, setIsMobile] = useState(false)
@@ -58,8 +60,10 @@ export function ChatPanel({ messages, input, setInput }: ChatPanelProps) {
       }
     ])
     const formData = new FormData(e.currentTarget)
+    setIsChatLoading(true)
     // Removed mcp argument from submit call
     const responseMessage = await submit(formData)
+    setIsChatLoading(false)
     setMessages(currentMessages => [...currentMessages, responseMessage as any])
   }
 

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -5,7 +5,7 @@ import { ModeToggle } from './mode-toggle'
 import { cn } from '@/lib/utils'
 import HistoryContainer from './history-container'
 import { Button } from '@/components/ui/button'
-import { useMapLoading } from '@/components/map-loading-context'
+import { useChatLoading } from '@/components/chat-loading-context'
 import '@/app/loading.css'
 import {
   Search,
@@ -18,7 +18,7 @@ import { MapToggle } from './map-toggle'
 import { ProfileToggle } from './profile-toggle'
 
 export const Header = () => {
-  const { isMapLoaded } = useMapLoading()
+  const { isChatLoading } = useChatLoading()
 
   return (
     <header className="fixed w-full p-1 md:p-2 flex justify-between items-center z-10 backdrop-blur md:backdrop-blur-none bg-background/80 md:bg-transparent">
@@ -35,7 +35,7 @@ export const Header = () => {
             alt="Logo"
             width={24}
             height={24}
-            className={cn('h-6 w-auto', { spinning: !isMapLoaded })}
+            className={cn('h-6 w-auto', { spinning: isChatLoading })}
           />
         </Button>
       </div>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,3 +1,4 @@
+'use client'
 import React from 'react'
 import Image from 'next/image'
 import { ModeToggle } from './mode-toggle'

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -4,6 +4,8 @@ import { ModeToggle } from './mode-toggle'
 import { cn } from '@/lib/utils'
 import HistoryContainer from './history-container'
 import { Button } from '@/components/ui/button'
+import { useMapLoading } from '@/components/map-loading-context'
+import '@/app/loading.css'
 import {
   Search,
   CircleUserRound,
@@ -15,6 +17,8 @@ import { MapToggle } from './map-toggle'
 import { ProfileToggle } from './profile-toggle'
 
 export const Header = () => {
+  const { isMapLoaded } = useMapLoading()
+
   return (
     <header className="fixed w-full p-1 md:p-2 flex justify-between items-center z-10 backdrop-blur md:backdrop-blur-none bg-background/80 md:bg-transparent">
       <div>
@@ -25,7 +29,13 @@ export const Header = () => {
       
       <div className="absolute left-1">
         <Button variant="ghost" size="icon">
-          <Image src="/images/logo.svg" alt="Logo" width={24} height={24} className="h-6 w-auto" />
+          <Image
+            src="/images/logo.svg"
+            alt="Logo"
+            width={24}
+            height={24}
+            className={cn('h-6 w-auto', { spinning: !isMapLoaded })}
+          />
         </Button>
       </div>
       

--- a/components/loading-spinner.tsx
+++ b/components/loading-spinner.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { useMapLoading } from '@/components/map-loading-context'
+import Image from 'next/image'
+import { useEffect, useState } from 'react'
+import '@/app/loading.css'
+
+const LoadingSpinner = () => {
+  const { isMapLoaded } = useMapLoading()
+  const [isVisible, setIsVisible] = useState(!isMapLoaded)
+
+  useEffect(() => {
+    let timer: NodeJS.Timeout
+    if (!isMapLoaded) {
+      setIsVisible(true)
+    } else {
+      timer = setTimeout(() => setIsVisible(false), 500) // Corresponds to fadeOut duration
+    }
+    return () => clearTimeout(timer)
+  }, [isMapLoaded])
+
+  if (!isVisible) return null
+
+  return (
+    <div
+      className={`fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 ${
+        isMapLoaded ? 'fade-out' : 'fade-in'
+      }`}
+    >
+      <Image
+        src="/images/logo.svg"
+        alt="Loading..."
+        width={100}
+        height={100}
+        className="spinning"
+      />
+    </div>
+  )
+}
+
+export default LoadingSpinner

--- a/components/loading-spinner.tsx
+++ b/components/loading-spinner.tsx
@@ -1,30 +1,30 @@
 'use client'
 
-import { useMapLoading } from '@/components/map-loading-context'
+import { useChatLoading } from '@/components/chat-loading-context'
 import Image from 'next/image'
 import { useEffect, useState } from 'react'
 import '@/app/loading.css'
 
 const LoadingSpinner = () => {
-  const { isMapLoaded } = useMapLoading()
-  const [isVisible, setIsVisible] = useState(!isMapLoaded)
+  const { isChatLoading } = useChatLoading()
+  const [isVisible, setIsVisible] = useState(isChatLoading)
 
   useEffect(() => {
     let timer: NodeJS.Timeout
-    if (!isMapLoaded) {
+    if (isChatLoading) {
       setIsVisible(true)
     } else {
       timer = setTimeout(() => setIsVisible(false), 500) // Corresponds to fadeOut duration
     }
     return () => clearTimeout(timer)
-  }, [isMapLoaded])
+  }, [isChatLoading])
 
   if (!isVisible) return null
 
   return (
     <div
       className={`fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 ${
-        isMapLoaded ? 'fade-out' : 'fade-in'
+        !isChatLoading ? 'fade-out' : 'fade-in'
       }`}
     >
       <Image


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add loading animation with spinning logo

- Create CSS keyframes for spin and fade effects

- Replace ConditionalLottie with LoadingSpinner component

- Integrate loading state with map loading context


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CSS Animations"] --> B["Loading Spinner Component"]
  B --> C["Header Logo Animation"]
  D["Map Loading Context"] --> B
  D --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>loading.css</strong><dd><code>Create CSS animations for loading states</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/loading.css

<ul><li>Define <code>spin</code> keyframe for 360-degree rotation animation<br> <li> Add <code>fadeIn</code> and <code>fadeOut</code> keyframes for opacity transitions<br> <li> Create CSS classes for spinning, fade-in, and fade-out effects</ul>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/207/files#diff-09da0fccf5986eebbeb6c39196ddd090c02d9e12846498f44839d7ae81d7ea8b">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>layout.tsx</strong><dd><code>Replace ConditionalLottie with LoadingSpinner component</code>&nbsp; &nbsp; </dd></summary>
<hr>

app/layout.tsx

<ul><li>Replace <code>ConditionalLottie</code> import with <code>LoadingSpinner</code><br> <li> Update component usage in layout structure</ul>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/207/files#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>header.tsx</strong><dd><code>Add spinning animation to header logo</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/header.tsx

<ul><li>Import <code>useMapLoading</code> hook and loading CSS<br> <li> Add conditional <code>spinning</code> class to logo based on map loading state<br> <li> Restructure logo Image component with dynamic className</ul>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/207/files#diff-cf7e29e4902dea0aa000da86f34225ba6d7a6d13c982343f255b15f827269199">+11/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>loading-spinner.tsx</strong><dd><code>Implement full-screen loading spinner component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/loading-spinner.tsx

<ul><li>Create new loading spinner component with fade transitions<br> <li> Implement visibility state management with useEffect<br> <li> Display spinning logo overlay during map loading<br> <li> Handle fade-out animation timing with setTimeout</ul>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/207/files#diff-e6a10189e271de18c9e1582e3e749e1e70bd6e9f162d45cf5c4cf9da409c424e">+41/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a fullscreen loading spinner with smooth fade-in and fade-out animations to indicate chat loading status.
  * Added a chat loading context to manage and share loading state across components.

* **Enhancements**
  * The header logo now spins while chat loading is active, providing a visual loading indicator.
  * Integrated chat loading state management into the chat panel for precise loading feedback.

* **Style**
  * Implemented new CSS animations for spinning and fading effects used in loading indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->