### PR TITLE
Fix: Generating a response after a search

### DIFF
--- a/app/actions.tsx
+++ b/app/actions.tsx
@@ -175,9 +175,9 @@ async function submit(formData?: FormData, skip?: boolean) {
       }
     }
 
-    // If useSpecificAPI is enabled, generate the answer using the specific model
-    if (useSpecificAPI && answer.length === 0) {
-      // Modify the messages to be used by the specific model
+    // If the researcher returns tool outputs, but no answer,
+    // generate a new response from the tool outputs using the writer agent.
+    if (toolOutputs.length > 0 && answer.length === 0) {
       const modifiedMessages = aiState.get().messages.map((msg) =>
         msg.role === 'tool'
           ? {
@@ -190,18 +190,6 @@ async function submit(formData?: FormData, skip?: boolean) {
       ) as CoreMessage[];
       const latestMessages = modifiedMessages.slice(maxMessages * -1);
       answer = await writer(currentSystemPrompt, uiStream, streamText, latestMessages);
-    } else if (toolOutputs.length > 0 && answer.length === 0) {
-      // If the researcher returns tool outputs, but no answer,
-      // generate a new response from the tool outputs
-      const { fullResponse } = await researcher(
-        currentSystemPrompt,
-        uiStream,
-        streamText,
-        aiState.get().messages as CoreMessage[],
-        useSpecificAPI,
-      );
-      answer = fullResponse;
-      streamText.done();
     } else {
       streamText.done();
     }

--- a/app/actions.tsx
+++ b/app/actions.tsx
@@ -190,6 +190,18 @@ async function submit(formData?: FormData, skip?: boolean) {
       ) as CoreMessage[];
       const latestMessages = modifiedMessages.slice(maxMessages * -1);
       answer = await writer(currentSystemPrompt, uiStream, streamText, latestMessages);
+    } else if (toolOutputs.length > 0 && answer.length === 0) {
+      // If the researcher returns tool outputs, but no answer,
+      // generate a new response from the tool outputs
+      const { fullResponse } = await researcher(
+        currentSystemPrompt,
+        uiStream,
+        streamText,
+        aiState.get().messages as CoreMessage[],
+        useSpecificAPI,
+      );
+      answer = fullResponse;
+      streamText.done();
     } else {
       streamText.done();
     }


### PR DESCRIPTION
### **User description**
I found an issue where I would fail to generate a response after an internet search when the `useSpecificAPI` flag was disabled.

I've modified the code in `app/actions.tsx` to correct this. Now, after I get results from a search, I will make sure to process them and formulate a final answer for you. This ensures you always get a response based on the information I find.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix missing response generation after search when `useSpecificAPI` is disabled

- Add fallback logic to generate answer from tool outputs

- Ensure researcher function processes search results into final response


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Search Tool Outputs"] --> B["Check useSpecificAPI Flag"]
  B --> C["Flag Enabled: Use Writer"]
  B --> D["Flag Disabled: Missing Response"]
  D --> E["New Fix: Call Researcher"]
  E --> F["Generate Final Answer"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>actions.tsx</strong><dd><code>Add fallback response generation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/actions.tsx

<ul><li>Add conditional check for tool outputs with empty answer<br> <li> Call researcher function to generate response from tool outputs<br> <li> Ensure streamText.done() is called after generating answer</ul>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/211/files#diff-5d789135759f172b94f5f9b4c62ad9f1410b79f4c8cff86ffed6464f22b61752">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

