### PR TITLE
Fix: Use correct initial zoom for mobile devices

### DIFF
--- a/components/map/mapbox-map.tsx
+++ b/components/map/mapbox-map.tsx
@@ -395,11 +395,12 @@ export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number
         initialZoom = 1.3;
       }
 
+      currentMapCenterRef.current.zoom = initialZoom;
       map.current = new mapboxgl.Map({
         container: mapContainer.current,
         style: 'mapbox://styles/mapbox/satellite-streets-v12',
         center: currentMapCenterRef.current.center,
-        zoom: currentMapCenterRef.current.zoom,
+        zoom: initialZoom,
         pitch: currentMapCenterRef.current.pitch,
         bearing: 0,
         maxZoom: 22,


### PR DESCRIPTION
### **User description**
The map component was not using the calculated `initialZoom` for mobile devices, causing the map to be zoomed in by default.

This commit fixes the issue by:
- Updating `currentMapCenterRef.current.zoom` with the `initialZoom` value.
- Using `initialZoom` when creating the `mapboxgl.Map` instance.

This ensures that mobile and tablet devices get the appropriate zoom level for a full globe preview.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix mobile device map zoom initialization issue

- Ensure correct initial zoom level for mobile/tablet devices

- Update map center reference with calculated zoom value


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Mobile Detection"] --> B["Calculate initialZoom"]
  B --> C["Update currentMapCenterRef.current.zoom"]
  B --> D["Use initialZoom in mapboxgl.Map"]
  C --> E["Consistent Zoom State"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mapbox-map.tsx</strong><dd><code>Fix mobile map zoom initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/map/mapbox-map.tsx

<ul><li>Add assignment of <code>initialZoom</code> to <code>currentMapCenterRef.current.zoom</code><br> <li> Replace hardcoded zoom reference with <code>initialZoom</code> variable in Map <br>constructor<br> <li> Ensure consistent zoom state between ref and map instance</ul>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/239/files#diff-ce7ea3ef85a6812c7da39941ffa47e8e0fadbb3fc7c391cf1cafd96303cf3a0f">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Map now opens with a consistent initial zoom across devices, aligning the displayed zoom with the internal state.
  - Startup zoom adapts to screen width (1.3 on narrow viewports, 2.0 on wider), improving first-load clarity and preventing unexpected zoom jumps.
  - Results in smoother initial interactions, especially when centering the map or returning to the current location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->