### PR TITLE
fix: Allow mobile chat to scroll

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -88,7 +88,6 @@
     height: 100vh;
     width: 100%;
     background-color: hsl(var(--background));
-    overflow: hidden;
   }
 
   .mobile-map-section {


### PR DESCRIPTION
The mobile layout container had `overflow: hidden` which prevented the chat messages area from scrolling when the content exceeded the viewport height. This change removes the `overflow: hidden` property from the `.mobile-layout-container` class in `app/globals.css` to allow the chat messages area to scroll as intended.