### PR TITLE
fix: Remove extra paperclip icon from mobile chat input

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -157,17 +157,19 @@ export function ChatPanel({ messages, input, setInput }: ChatPanelProps) {
                 Math.max(8, newBorder) + 'px'
             }}
           />
-          <Button
-            type="button"
-            variant={'ghost'}
-            size={'icon'}
-            className={cn(
-              'absolute top-1/2 transform -translate-y-1/2',
-              isMobile ? 'right-8' : 'right-10'
-            )}
-          >
-            <Paperclip size={isMobile ? 18 : 20} />
-          </Button>
+          {!isMobile && (
+            <Button
+              type="button"
+              variant={'ghost'}
+              size={'icon'}
+              className={cn(
+                'absolute top-1/2 transform -translate-y-1/2',
+                isMobile ? 'right-8' : 'right-10'
+              )}
+            >
+              <Paperclip size={isMobile ? 18 : 20} />
+            </Button>
+          )}
           <Button
             type="submit"
             size={'icon'}

--- a/jules-scratch/verification/verify_attachment_icon.py
+++ b/jules-scratch/verification/verify_attachment_icon.py
@@ -1,0 +1,21 @@
+from playwright.sync_api import sync_playwright
+
+def run(playwright):
+    browser = playwright.chromium.launch()
+    context = browser.new_context()
+    page = context.new_page()
+
+    page.goto("http://localhost:3000")
+
+    # Mobile view
+    page.set_viewport_size({"width": 375, "height": 812})
+    page.screenshot(path="jules-scratch/verification/mobile_view.png")
+
+    # Desktop view
+    page.set_viewport_size({"width": 1920, "height": 1080})
+    page.screenshot(path="jules-scratch/verification/desktop_view.png")
+
+    browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)


### PR DESCRIPTION
Removes the duplicate attachment (Paperclip) icon from the mobile chat input bar.

The icon was appearing in both the chat input bar and the mobile icons scroll bar. This change conditionally renders the icon in the chat input bar only on desktop, using the existing `isMobile` state.

This resolves the redundancy while keeping the icon accessible in the mobile icons scroll bar and on the desktop version of the chat input.