### PR TITLE
Fix "New Chat" button state issue

### DIFF
--- a/app/actions.tsx
+++ b/app/actions.tsx
@@ -1,3 +1,5 @@
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
 import {
   StreamableValue,
   createAI,
@@ -248,6 +250,12 @@ async function submit(formData?: FormData, skip?: boolean) {
   };
 }
 
+async function newChat() {
+  'use server';
+  revalidatePath('/');
+  redirect('/');
+}
+
 export type AIState = {
   messages: AIMessage[];
   chatId: string;
@@ -272,6 +280,7 @@ const initialUIState: UIState = [];
 export const AI = createAI<AIState, UIState>({
   actions: {
     submit,
+    newChat,
   },
   initialUIState,
   initialAIState,

--- a/app/actions.tsx
+++ b/app/actions.tsx
@@ -1,4 +1,3 @@
-import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import {
   StreamableValue,
@@ -251,9 +250,17 @@ async function submit(formData?: FormData, skip?: boolean) {
 }
 
 async function newChat() {
-  'use server';
-  revalidatePath('/');
-  redirect('/');
+  'use server'
+  const aiState = getMutableAIState<typeof AI>()
+
+  // Update AI state to a new session.
+  aiState.done({
+    ...initialAIState,
+    chatId: nanoid(),
+    messages: []
+  })
+
+  redirect('/')
 }
 
 export type AIState = {

--- a/app/actions.tsx
+++ b/app/actions.tsx
@@ -1,4 +1,3 @@
-import { redirect } from 'next/navigation';
 import {
   StreamableValue,
   createAI,
@@ -259,8 +258,6 @@ async function newChat() {
     chatId: nanoid(),
     messages: []
   })
-
-  redirect('/')
 }
 
 export type AIState = {

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useEffect, useState, useRef } from 'react'
-import { useRouter } from 'next/navigation'
 import type { AI, UIState } from '@/app/actions'
 import { useUIState, useActions } from 'ai/rsc'
 // Removed import of useGeospatialToolMcp as it's no longer used/available
@@ -20,12 +19,11 @@ interface ChatPanelProps {
 
 export function ChatPanel({ messages, input, setInput }: ChatPanelProps) {
   const [, setMessages] = useUIState<typeof AI>()
-  const { submit } = useActions()
+  const { submit, newChat } = useActions()
   // Removed mcp instance as it's no longer passed to submit
   const [isButtonPressed, setIsButtonPressed] = useState(false)
   const [isMobile, setIsMobile] = useState(false)
   const inputRef = useRef<HTMLTextAreaElement>(null)
-  const router = useRouter()
 
   // Detect mobile layout
   useEffect(() => {
@@ -64,7 +62,7 @@ export function ChatPanel({ messages, input, setInput }: ChatPanelProps) {
   }
 
   const handleClear = () => {
-    router.push('/')
+    newChat()
   }
 
   useEffect(() => {

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -63,6 +63,7 @@ export function ChatPanel({ messages, input, setInput }: ChatPanelProps) {
 
   const handleClear = async () => {
     await newChat()
+    window.location.href = '/'
   }
 
   useEffect(() => {

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -45,7 +45,7 @@ export function ChatPanel({ messages, input, setInput }: ChatPanelProps) {
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
     if (isButtonPressed) {
-      handleClear()
+      await handleClear()
       setIsButtonPressed(false)
     }
     setMessages(currentMessages => [
@@ -61,8 +61,8 @@ export function ChatPanel({ messages, input, setInput }: ChatPanelProps) {
     setMessages(currentMessages => [...currentMessages, responseMessage as any])
   }
 
-  const handleClear = () => {
-    newChat()
+  const handleClear = async () => {
+    await newChat()
   }
 
   useEffect(() => {

--- a/components/mobile-icons-bar.tsx
+++ b/components/mobile-icons-bar.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React from 'react'
-import { useRouter } from 'next/navigation'
+import { useActions } from 'ai/rsc'
 import { Button } from '@/components/ui/button'
 import {
   Search,
@@ -18,10 +18,10 @@ import { MapToggle } from './map-toggle'
 import { ModeToggle } from './mode-toggle'
 
 export const MobileIconsBar: React.FC = () => {
-  const router = useRouter()
+  const { newChat } = useActions()
 
   const handleNewChat = () => {
-    router.push('/')
+    newChat()
   }
 
   return (

--- a/components/mobile-icons-bar.tsx
+++ b/components/mobile-icons-bar.tsx
@@ -20,8 +20,8 @@ import { ModeToggle } from './mode-toggle'
 export const MobileIconsBar: React.FC = () => {
   const { newChat } = useActions()
 
-  const handleNewChat = () => {
-    newChat()
+  const handleNewChat = async () => {
+    await newChat()
   }
 
   return (

--- a/components/mobile-icons-bar.tsx
+++ b/components/mobile-icons-bar.tsx
@@ -22,6 +22,7 @@ export const MobileIconsBar: React.FC = () => {
 
   const handleNewChat = async () => {
     await newChat()
+    window.location.href = '/'
   }
 
   return (


### PR DESCRIPTION
### **User description**
The "New Chat" button was not properly clearing the application state. It was using client-side navigation (`router.push('/')`), which did not trigger a server-side state reset.

This commit fixes the issue by:
- Creating a new server action `newChat` in `app/actions.tsx` that calls `revalidatePath('/')` and `redirect('/')` to ensure a full state reset.
- Modifying the "New Chat" buttons in `components/chat-panel.tsx` (desktop) and `components/mobile-icons-bar.tsx` (mobile) to use this new server action.


___

### **PR Type**
Bug fix


___

### **Description**
- Replace client-side navigation with server action for "New Chat" button

- Add `newChat` server action with proper state reset

- Update both desktop and mobile components to use new action

- Ensure full application state clearing on new chat


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Client-side router.push('/')"] --> B["Server action newChat()"]
  B --> C["revalidatePath('/')"]
  B --> D["redirect('/')"]
  C --> E["Full state reset"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>actions.tsx</strong><dd><code>Add server action for new chat functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/actions.tsx

<ul><li>Add imports for <code>revalidatePath</code> and <code>redirect</code> from Next.js<br> <li> Create new <code>newChat</code> server action that revalidates path and redirects<br> <li> Export <code>newChat</code> action in AI provider actions</ul>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/252/files#diff-5d789135759f172b94f5f9b4c62ad9f1410b79f4c8cff86ffed6464f22b61752">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chat-panel.tsx</strong><dd><code>Replace client navigation with server action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/chat-panel.tsx

<ul><li>Remove <code>useRouter</code> import and router instance<br> <li> Import <code>newChat</code> action from useActions hook<br> <li> Replace <code>router.push('/')</code> with <code>newChat()</code> in handleClear function</ul>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/252/files#diff-06a509597829dfc3e720c47b51047e08ba858772f51c5dfd2e01bd6deefb4241">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mobile-icons-bar.tsx</strong><dd><code>Update mobile new chat to use server action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/mobile-icons-bar.tsx

<ul><li>Replace <code>useRouter</code> import with <code>useActions</code> from ai/rsc<br> <li> Update handleNewChat to use <code>newChat()</code> server action<br> <li> Remove router dependency for new chat functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/252/files#diff-9f258d33f15a037a252e9debe448117217cb455ef07d7e024426ab00e7f90851">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - “New chat” now fully resets your conversation and returns you to the home screen for a clean start, on both desktop and mobile.

- Bug Fixes
  - Improved reliability when starting a new chat: the app now completes clearing the previous session before continuing.
  - More consistent navigation after creating a new chat, reducing chances of partial or stale conversations.
  - Submit actions now wait for the new chat flow to finish when triggered concurrently, preventing interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->