### PR TITLE
fix(mobile): Move chat input into horizontally scrolling container

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -160,40 +160,6 @@
     box-sizing: border-box;
   }
 
-  .mobile-chat-input-area {
-    height: 70px;
-    padding: 10px;
-    background-color: hsl(var(--background));
-    /* border-top: 1px solid hsl(var(--border)); */ /* Removed for cleaner separation */
-    border-bottom: 1px solid hsl(var(--border)); /* Added for separation from messages area below */
-    box-sizing: border-box;
-    /* z-index: 30; */ /* No longer needed as it's in flow */
-    display: flex;
-    align-items: center;
-  }
-
-  .mobile-chat-input {
-    /* position: relative; */ /* No longer fixed to bottom */
-    /* bottom: 0; */
-    /* left: 0; */ /* Handled by parent flex */
-    /* right: 0; */ /* Handled by parent flex */
-    width: 100%; /* Ensure it takes full width of its container */
-    padding: 10px;
-    background-color: hsl(var(--background));
-    /* border-top: 1px solid hsl(var(--border)); */ /* Removed to avoid double border */
-    /* z-index: 30; */ /* No longer needed */
-  }
-
-  .mobile-chat-input input {
-    width: 100%;
-    padding: 8px;
-    border: 1px solid hsl(var(--input));
-    border-radius: var(--radius);
-    background-color: hsl(var(--input));
-    color: hsl(var(--foreground));
-    box-sizing: border-box;
-  }
-
   .mobile-icons-bar-content .icon-button {
     display: flex;
     align-items: center;
@@ -209,23 +175,6 @@
   .mobile-icons-bar-content .icon-button:hover {
     background-color: hsl(var(--secondary-foreground));
     color: hsl(var(--secondary));
-  }
-
-  .mobile-chat-input .icon-button {
-    position: absolute;
-    top: 50%;
-    transform: translateY(-50%);
-    background-color: transparent;
-    border: none;
-    cursor: pointer;
-  }
-
-  .mobile-chat-input .icon-button.paperclip {
-    right: 40px;
-  }
-
-  .mobile-chat-input .icon-button.arrow-right {
-    right: 10px;
   }
 }
 

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -88,14 +88,14 @@ export function ChatPanel({ messages, input, setInput }: ChatPanelProps) {
       className={cn(
         'flex flex-col items-start',
         isMobile
-          ? 'w-full h-full'
+          ? 'w-auto'
           : 'sticky bottom-0 bg-background z-10 w-full border-t border-border px-2 py-3 md:px-4'
       )}
     >
       <form
         ref={formRef}
         onSubmit={handleSubmit}
-        className={cn('max-w-full w-full', isMobile ? 'px-2 pb-2 pt-1 h-full flex flex-col justify-center' : '')}
+        className={cn('max-w-full w-full', isMobile ? 'px-2 pb-2 pt-1 flex flex-col justify-center' : '')}
       >
         <div
           className={cn(

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -80,10 +80,9 @@ export function Chat({ id }: ChatProps) {
             {activeView ? <SettingsView /> : <Mapbox />}
           </div>
           <div className="mobile-icons-bar">
-            <MobileIconsBar />
-          </div>
-          <div className="mobile-chat-input-area">
-            <ChatPanel messages={messages} input={input} setInput={setInput} />
+            <MobileIconsBar>
+              <ChatPanel messages={messages} input={input} setInput={setInput} />
+            </MobileIconsBar>
           </div>
           <div className="mobile-chat-messages-area">
             {showEmptyScreen ? (

--- a/components/mobile-icons-bar.tsx
+++ b/components/mobile-icons-bar.tsx
@@ -18,7 +18,9 @@ import { History } from '@/components/history'
 import { MapToggle } from './map-toggle'
 import { ModeToggle } from './mode-toggle'
 
-export const MobileIconsBar: React.FC = () => {
+export const MobileIconsBar: React.FC<{ children?: React.ReactNode }> = ({
+  children
+}) => {
   const [, setMessages] = useUIState<typeof AI>()
   const { clearChat } = useActions()
 
@@ -53,6 +55,7 @@ export const MobileIconsBar: React.FC = () => {
       </Button>
       <History location="header" />
       <ModeToggle />
+      {children}
     </div>
   )
 }


### PR DESCRIPTION
### **User description**
The chat input was previously located outside the horizontally scrolling icon bar on mobile devices, making it unreachable when the user scrolled.

This change refactors the mobile layout by moving the ChatPanel component to be a child of the MobileIconsBar component. This places the chat input inside the same scrollable container as the other icons, making it accessible.

- Modified `components/chat.tsx` to update the component hierarchy for the mobile layout.
- Updated `components/mobile-icons-bar.tsx` to accept and render child components.
- Adjusted styling in `components/chat-panel.tsx` to ensure it fits correctly within the icon bar.
- Removed unused CSS rules from `app/globals.css` that were related to the old layout.


___

### **PR Type**
Bug fix


___

### **Description**
- Move chat input into horizontally scrolling container

- Remove unused mobile chat input CSS rules

- Update component hierarchy for mobile layout

- Accept children in MobileIconsBar component


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["MobileIconsBar"] --> B["ChatPanel"]
  C["CSS Rules"] --> D["Removed unused styles"]
  E["Mobile Layout"] --> F["Improved accessibility"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>globals.css</strong><dd><code>Remove unused mobile chat input styles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/globals.css

<ul><li>Remove <code>.mobile-chat-input-area</code> CSS class and related styles<br> <li> Remove <code>.mobile-chat-input</code> and button positioning styles<br> <li> Clean up unused mobile chat input styling rules</ul>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/293/files#diff-79e0914d9fee5ca4432bdb002a24d700d31b5577265f4de3f90d5c292b9f1392">+0/-51</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chat-panel.tsx</strong><dd><code>Adjust ChatPanel mobile styling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/chat-panel.tsx

<ul><li>Change mobile width from <code>w-full h-full</code> to <code>w-auto</code><br> <li> Remove <code>h-full</code> class from mobile form styling<br> <li> Adjust container dimensions for icon bar integration</ul>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/293/files#diff-06a509597829dfc3e720c47b51047e08ba858772f51c5dfd2e01bd6deefb4241">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chat.tsx</strong><dd><code>Refactor mobile layout component hierarchy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/chat.tsx

<ul><li>Move ChatPanel as child of MobileIconsBar component<br> <li> Remove separate <code>mobile-chat-input-area</code> div container<br> <li> Restructure mobile layout component hierarchy</ul>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/293/files#diff-015689ed51facf46aa073450a0660cfa8b56e37b6b94248a56ec66550007f31b">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mobile-icons-bar.tsx</strong><dd><code>Add children support to MobileIconsBar</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/mobile-icons-bar.tsx

<ul><li>Add optional <code>children</code> prop to component interface<br> <li> Render children components within the icons bar<br> <li> Update component to accept and display child elements</ul>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/293/files#diff-9f258d33f15a037a252e9debe448117217cb455ef07d7e024426ab00e7f90851">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Mobile toolbar now supports embedding additional content within it.

- Refactor
  - Chat panel is now nested within the mobile icons bar for a more cohesive mobile layout.

- Style
  - Removed the fixed bottom mobile chat input area; input now follows the surrounding flex layout.
  - Adjusted mobile sizing to avoid forcing full-height panels, improving vertical space usage and alignment.

- Bug Fixes
  - Eliminated overlapping/absolute-positioned icon button rules on mobile, reducing layout conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->