### PR TITLE
fix(map): preserve map view on entering drawing mode

### DIFF
--- a/components/map/mapbox-map.tsx
+++ b/components/map/mapbox-map.tsx
@@ -234,10 +234,14 @@ export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number
   // Set up drawing tools
   const setupDrawingTools = useCallback(() => {
     if (!map.current || !drawRef.current) return;
-    
-    // Add the existing control to the map.
+
     map.current.addControl(drawRef.current, 'top-right');
-    
+
+    // Set up event listeners for measurements
+    map.current.on('draw.create', updateMeasurementLabels);
+    map.current.on('draw.delete', updateMeasurementLabels);
+    map.current.on('draw.update', updateMeasurementLabels);
+
     // Restore the map's view state after a brief delay.
     setTimeout(() => {
       if (map.current) {
@@ -246,8 +250,8 @@ export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number
         map.current.setPitch(pitch);
         map.current.setCenter(center);
       }
-    }, 0);
-    
+    }, 150);
+
     // Restore previous drawings if they exist.
     if (drawingFeatures.current) {
       drawRef.current.set(drawingFeatures.current);
@@ -330,6 +334,11 @@ export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number
           try {
             // Save current drawings before removing control
             drawingFeatures.current = drawRef.current.getAll();
+
+            // Detach event listeners
+            map.current.off('draw.create', updateMeasurementLabels);
+            map.current.off('draw.delete', updateMeasurementLabels);
+            map.current.off('draw.update', updateMeasurementLabels);
 
             map.current.removeControl(drawRef.current);
             
@@ -417,11 +426,6 @@ export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number
           },
           defaultMode: 'draw_polygon'
         });
-
-        // Set up event listeners for measurements once
-        map.current.on('draw.create', updateMeasurementLabels);
-        map.current.on('draw.delete', updateMeasurementLabels);
-        map.current.on('draw.update', updateMeasurementLabels);
 
         // Initialize drawing tools based on initial mode
         if (mapType === MapToggleEnum.DrawingMode) {

--- a/components/map/mapbox-map.tsx
+++ b/components/map/mapbox-map.tsx
@@ -268,6 +268,15 @@ export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number
     
     // Add control to map
     map.current.addControl(drawRef.current, 'top-right')
+
+    // Restore the map's view state
+    const { center, zoom, pitch } = currentMapCenterRef.current
+    map.current.flyTo({
+      center,
+      zoom,
+      pitch,
+      duration: 0 // Fly instantly
+    })
     
     // Set up event listeners for measurements
     map.current.on('draw.create', updateMeasurementLabels)

--- a/components/map/mapbox-map.tsx
+++ b/components/map/mapbox-map.tsx
@@ -273,12 +273,9 @@ export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number
     setTimeout(() => {
       if (map.current) {
         const { center, zoom, pitch } = currentMapCenterRef.current
-        map.current.flyTo({
-          center,
-          zoom,
-          pitch,
-          duration: 0 // Fly instantly
-        })
+        map.current.setZoom(zoom)
+        map.current.setPitch(pitch)
+        map.current.setCenter(center)
       }
     }, 0)
     

--- a/components/map/mapbox-map.tsx
+++ b/components/map/mapbox-map.tsx
@@ -269,14 +269,18 @@ export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number
     // Add control to map
     map.current.addControl(drawRef.current, 'top-right')
 
-    // Restore the map's view state
-    const { center, zoom, pitch } = currentMapCenterRef.current
-    map.current.flyTo({
-      center,
-      zoom,
-      pitch,
-      duration: 0 // Fly instantly
-    })
+    // Restore the map's view state after a brief delay to ensure it's not overridden
+    setTimeout(() => {
+      if (map.current) {
+        const { center, zoom, pitch } = currentMapCenterRef.current
+        map.current.flyTo({
+          center,
+          zoom,
+          pitch,
+          duration: 0 // Fly instantly
+        })
+      }
+    }, 0)
     
     // Set up event listeners for measurements
     map.current.on('draw.create', updateMeasurementLabels)


### PR DESCRIPTION
### **User description**
When activating the drawing mode, the map would zoom out to the globe level instead of maintaining the current zoom and position.

This was caused by the `setupDrawingTools` function not restoring the map's view state after adding the MapboxDraw control.

This commit fixes the issue by explicitly restoring the map's center, zoom, and pitch from a stored reference immediately after the drawing control is added. A `flyTo` with a duration of 0 is used to make the transition seamless for the user.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix map view preservation when entering drawing mode

- Restore center, zoom, and pitch after adding MapboxDraw control

- Use instant flyTo transition for seamless user experience


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Drawing mode activated"] --> B["MapboxDraw control added"]
  B --> C["Map view state restored"]
  C --> D["flyTo with duration 0"]
  D --> E["Seamless transition maintained"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mapbox-map.tsx</strong><dd><code>Restore map view after drawing control setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/map/mapbox-map.tsx

<ul><li>Add map view state restoration after adding MapboxDraw control<br> <li> Use <code>flyTo</code> with zero duration for instant transition<br> <li> Preserve center, zoom, and pitch from <code>currentMapCenterRef</code></ul>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/294/files#diff-ce7ea3ef85a6812c7da39941ffa47e8e0fadbb3fc7c391cf1cafd96303cf3a0f">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserves your current map view (center, zoom, pitch) on map initialization to avoid unexpected jumps.
  * Retains and restores ongoing drawings when switching drawing mode on/off so work is not lost.
  * Improves drawing toolbar initialization for smoother transitions and fewer interruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->