### PR TITLE
Fix(mobile): Correct mobile chat component order to enable scrolling

### DIFF
--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -75,16 +75,12 @@ export function Chat({ id }: ChatProps) {
   if (isMobile) {
     return (
       <MapDataProvider> {/* Add Provider */}
+        {/* The order of components here is critical for mobile layout.
+            Using a flex column, the .mobile-chat-messages-area is set to flex: 1
+            which allows it to take up the remaining space. The other components
+            have fixed heights, so for the chat area to scroll properly, it must
+            be rendered before the fixed-height elements. */}
         <div className="mobile-layout-container">
-          <div className="mobile-map-section">
-            {activeView ? <SettingsView /> : <Mapbox />}
-          </div>
-          <div className="mobile-icons-bar">
-            <MobileIconsBar />
-          </div>
-          <div className="mobile-chat-input-area">
-            <ChatPanel messages={messages} input={input} setInput={setInput} />
-          </div>
           <div className="mobile-chat-messages-area">
             {showEmptyScreen ? (
               <EmptyScreen
@@ -95,6 +91,15 @@ export function Chat({ id }: ChatProps) {
             ) : (
               <ChatMessages messages={messages} />
             )}
+          </div>
+          <div className="mobile-chat-input-area">
+            <ChatPanel messages={messages} input={input} setInput={setInput} />
+          </div>
+          <div className="mobile-icons-bar">
+            <MobileIconsBar />
+          </div>
+          <div className="mobile-map-section">
+            {activeView ? <SettingsView /> : <Mapbox />}
           </div>
         </div>
       </MapDataProvider>


### PR DESCRIPTION
### **User description**
The mobile chat view had a scrolling issue because the component order in `components/chat.tsx` did not allow the chat message area to expand correctly. The flexbox layout requires the scrollable element with `flex: 1` to be ordered before the fixed-height elements to calculate its height properly.

This commit reorders the components to place the chat message area first, which resolves the scrolling problem. A comment has also been added to the code to explain the importance of this order for any future modifications.


___

### **PR Type**
Bug fix


___

### **Description**
- Reorder mobile chat components to fix scrolling issue

- Add explanatory comment for component order importance

- Move chat messages area before fixed-height elements


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Mobile Chat Container"] --> B["Chat Messages Area (flex: 1)"]
  B --> C["Chat Input Area (fixed height)"]
  C --> D["Icons Bar (fixed height)"]
  D --> E["Map Section (fixed height)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chat.tsx</strong><dd><code>Reorder mobile components for proper scrolling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/chat.tsx

<ul><li>Reordered mobile layout components to fix flexbox scrolling<br> <li> Moved <code>mobile-chat-messages-area</code> to first position<br> <li> Added detailed comment explaining component order importance<br> <li> Moved fixed-height elements after scrollable area</ul>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/296/files#diff-015689ed51facf46aa073450a0660cfa8b56e37b6b94248a56ec66550007f31b">+14/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile chat layout: messages appear first, with input and action bar positioned after, enhancing readability.
  * Fixed mobile scrolling so the messages area expands correctly alongside fixed-height input/actions.
  * Ensured map drawings update reliably during chats, reducing inconsistencies in displayed drawing state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->