### PR TITLE
feat: Improve calendar UI and widen desktop layout for collaborative workflows

### DIFF
--- a/components/calendar-notepad.tsx
+++ b/components/calendar-notepad.tsx
@@ -91,7 +91,7 @@ export function CalendarNotepad({ chatId }: CalendarNotepadProps) {
   };
 
   return (
-    <div data-testid="calendar-notepad" className="bg-card text-card-foreground shadow-lg rounded-lg p-4 max-w-2xl mx-auto my-4 border">
+    <div data-testid="calendar-notepad" className="bg-card text-card-foreground shadow-lg rounded-lg p-4 w-full my-4 border">
       <div className="flex items-center justify-between mb-4">
         <button
           onClick={() => setDateOffset(dateOffset - 7)}

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -120,7 +120,7 @@ export function Chat({ id }: ChatProps) {
       <HeaderSearchButton />
       <div className="flex justify-start items-start">
         {/* This is the new div for scrolling */}
-      <div className="w-1/2 flex flex-col space-y-3 md:space-y-4 px-8 sm:px-12 pt-12 md:pt-14 pb-4 h-[calc(100vh-0.5in)] overflow-y-auto">
+      <div className="w-3/5 flex flex-col space-y-3 md:space-y-4 px-8 sm:px-12 pt-12 md:pt-14 pb-4 h-[calc(100vh-0.5in)] overflow-y-auto">
         {isCalendarOpen ? (
           <CalendarNotepad chatId={id} />
         ) : (
@@ -139,7 +139,7 @@ export function Chat({ id }: ChatProps) {
         )}
       </div>
         <div
-          className="w-1/2 p-4 fixed h-[calc(100vh-0.5in)] top-0 right-0 mt-[0.5in]"
+          className="w-2/5 p-4 fixed h-[calc(100vh-0.5in)] top-0 right-0 mt-[0.5in]"
           style={{ zIndex: 10 }} // Added z-index
         >
           {activeView ? <SettingsView /> : <Mapbox />}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -17,7 +17,7 @@ import { MapToggle } from './map-toggle'
 import { ProfileToggle } from './profile-toggle'
 
 export const Header = () => {
-  const { toggleCalendar } = useCalendarToggle()
+  const { toggleCalendar, isCalendarOpen } = useCalendarToggle()
   return (
     <header className="fixed w-full p-1 md:p-2 flex justify-between items-center z-10 backdrop-blur md:backdrop-blur-none bg-background/80 md:bg-transparent">
       <div>
@@ -38,7 +38,7 @@ export const Header = () => {
         
         <MapToggle />
         
-        <Button variant="ghost" size="icon" onClick={toggleCalendar} title="Open Calendar">
+        <Button variant="ghost" size="icon" onClick={toggleCalendar} title="Open Calendar" className={cn(isCalendarOpen && "bg-accent")}>
           <CalendarDays className="h-[1.2rem] w-[1.2rem]" />
         </Button>
         

--- a/components/mobile-icons-bar.tsx
+++ b/components/mobile-icons-bar.tsx
@@ -26,7 +26,7 @@ interface MobileIconsBarProps {
 export const MobileIconsBar: React.FC<MobileIconsBarProps> = ({ onAttachmentClick }) => {
   const [, setMessages] = useUIState<typeof AI>()
   const { clearChat } = useActions()
-  const { toggleCalendar } = useCalendarToggle()
+  const { toggleCalendar, isCalendarOpen } = useCalendarToggle()
 
   const handleNewChat = async () => {
     setMessages([])
@@ -42,7 +42,7 @@ export const MobileIconsBar: React.FC<MobileIconsBarProps> = ({ onAttachmentClic
         <CircleUserRound className="h-[1.2rem] w-[1.2rem]" />
       </Button>
       <MapToggle />
-      <Button variant="ghost" size="icon" onClick={toggleCalendar} title="Open Calendar">
+      <Button variant="ghost" size="icon" onClick={toggleCalendar} title="Open Calendar" className={isCalendarOpen ? "bg-accent" : ""}>
         <CalendarDays className="h-[1.2rem] w-[1.2rem] transition-all rotate-0 scale-100" />
       </Button>
       <Button variant="ghost" size="icon">


### PR DESCRIPTION
### **User description**
## Summary

This PR improves the calendar functionality and desktop UI layout to better support collaborative geospatial workflows.

## Changes Made

### 1. Desktop Layout Width Adjustment
- **Chat/Calendar area**: Widened from 50% to 60% width
- **Map area**: Reduced from 50% to 40% width
- Provides 20% more horizontal space for collaborative context

### 2. Calendar Notepad Full Width
- Removed `max-w-2xl` constraint
- Changed to `w-full` to use the full available width
- Better display of survey requirements and detailed planning

### 3. Calendar Icon Visual Feedback
- Added active state highlighting with `bg-accent` background
- Clear visual indication when calendar is open
- Consistent across desktop and mobile

## Use Case Alignment

These changes support the intended use case for calendar-centric collaborative geospatial workflows:
- Users add time-sensitive context about geospatial work
- Collaborate asynchronously with team members
- Tag locations and collaborators
- Set reminders for future events (e.g., municipal land divisions)
- More space for survey requirements and detailed notes

## Files Modified

- `components/chat.tsx`: Desktop layout width adjustments (60/40 split)
- `components/calendar-notepad.tsx`: Full width usage
- `components/header.tsx`: Calendar icon active state (desktop)
- `components/mobile-icons-bar.tsx`: Calendar icon active state (mobile)

## Testing

- [x] Desktop layout shows 60/40 split
- [x] Calendar notepad uses full width
- [x] Calendar icon highlights when active (desktop)
- [x] Calendar icon highlights when active (mobile)
- [x] All existing functionality preserved
- [x] Mobile layout unchanged

## Impact

- **No breaking changes**
- **No new dependencies**
- **Zero performance impact** (CSS-only changes)
- **Backward compatible**

## Screenshots

The desktop UI now provides significantly more space for:
- Survey requirements and detailed planning
- Multiple collaborator tags and mentions
- Location context and future event planning
- Better information density and readability


___

### **PR Type**
Enhancement


___

### **Description**
- Widen desktop chat/calendar area from 50% to 60% width

- Reduce desktop map area from 50% to 40% width

- Remove max-width constraint from calendar notepad

- Add visual feedback to calendar icon when active


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Desktop Layout"] -->|"Adjust widths"| B["Chat/Calendar: 50% → 60%"]
  A -->|"Adjust widths"| C["Map: 50% → 40%"]
  D["Calendar Notepad"] -->|"Remove constraint"| E["max-w-2xl → w-full"]
  F["Calendar Icon"] -->|"Add active state"| G["bg-accent highlight"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>calendar-notepad.tsx</strong><dd><code>Remove max-width constraint from calendar notepad</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/calendar-notepad.tsx

<ul><li>Removed <code>max-w-2xl mx-auto</code> width constraint<br> <li> Changed to <code>w-full</code> for full available width<br> <li> Allows calendar notepad to expand and utilize desktop space</ul>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/356/files#diff-34abed9f4c61fdfa4ab73f359d6ea656c13d2baed07139d963b90bd5f39c232c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chat.tsx</strong><dd><code>Adjust desktop layout width split ratio</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/chat.tsx

<ul><li>Changed chat/calendar container width from <code>w-1/2</code> to <code>w-3/5</code> (50% to 60%)<br> <li> Changed map container width from <code>w-1/2</code> to <code>w-2/5</code> (50% to 40%)<br> <li> Provides 20% more horizontal space for collaborative context</ul>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/356/files#diff-015689ed51facf46aa073450a0660cfa8b56e37b6b94248a56ec66550007f31b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>header.tsx</strong><dd><code>Add active state styling to calendar icon</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/header.tsx

<ul><li>Extract <code>isCalendarOpen</code> state from <code>useCalendarToggle</code> hook<br> <li> Add conditional <code>bg-accent</code> class to calendar button when active<br> <li> Provides visual feedback for calendar open state on desktop</ul>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/356/files#diff-cf7e29e4902dea0aa000da86f34225ba6d7a6d13c982343f255b15f827269199">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mobile-icons-bar.tsx</strong><dd><code>Add active state styling to mobile calendar icon</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/mobile-icons-bar.tsx

<ul><li>Extract <code>isCalendarOpen</code> state from <code>useCalendarToggle</code> hook<br> <li> Add conditional <code>bg-accent</code> class to calendar button when active<br> <li> Provides visual feedback for calendar open state on mobile</ul>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/356/files#diff-9f258d33f15a037a252e9debe448117217cb455ef07d7e024426ab00e7f90851">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Calendar notepad now spans full available width for improved space utilization.
  * Adjusted chat layout proportions to allocate more space to the main content area.
  * Calendar button now visually highlights when the calendar is open for better UI feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->