### PR TITLE
Add counter-clockwise spinning plant icon during token generation

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,6 +16,7 @@ import { CalendarToggleProvider } from '@/components/calendar-toggle-context'
 import { MapLoadingProvider } from '@/components/map-loading-context';
 import ConditionalLottie from '@/components/conditional-lottie';
 import { MapProvider } from '@/components/map/map-context'
+import { StreamingProvider } from '@/components/streaming-context'
 
 const fontSans = FontSans({
   subsets: ['latin'],
@@ -60,8 +61,9 @@ export default function RootLayout({
         <CalendarToggleProvider>
           <MapToggleProvider>
             <ProfileToggleProvider>
-              <ThemeProvider
-                attribute="class"
+              <StreamingProvider>
+                <ThemeProvider
+                  attribute="class"
               defaultTheme="earth"
               enableSystem
               disableTransitionOnChange
@@ -77,9 +79,10 @@ export default function RootLayout({
                   <Toaster />
                 </MapLoadingProvider>
               </MapProvider>
-            </ThemeProvider>
-          </ProfileToggleProvider>
-        </MapToggleProvider>
+              </ThemeProvider>
+              </StreamingProvider>
+            </ProfileToggleProvider>
+          </MapToggleProvider>
         </CalendarToggleProvider>
         <Analytics />
         <SpeedInsights />

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -16,6 +16,7 @@ import { MapDataProvider, useMapData } from './map/map-data-context'; // Add thi
 import { updateDrawingContext } from '@/lib/actions/chat'; // Import the server action
 import dynamic from 'next/dynamic'
 import { HeaderSearchButton } from './header-search-button'
+import { StreamingProvider } from './streaming-context'
 
 type ChatProps = {
   id?: string // This is the chatId
@@ -84,8 +85,9 @@ export function Chat({ id }: ChatProps) {
   // Mobile layout
   if (isMobile) {
     return (
-      <MapDataProvider> {/* Add Provider */}
-        <HeaderSearchButton />
+      <StreamingProvider>
+        <MapDataProvider> {/* Add Provider */}
+          <HeaderSearchButton />
         <div className="mobile-layout-container">
           <div className="mobile-map-section">
           {activeView ? <SettingsView /> : <Mapbox />}
@@ -110,14 +112,16 @@ export function Chat({ id }: ChatProps) {
           )}
         </div>
         </div>
-      </MapDataProvider>
+        </MapDataProvider>
+      </StreamingProvider>
     );
   }
 
   // Desktop layout
   return (
-    <MapDataProvider> {/* Add Provider */}
-      <HeaderSearchButton />
+    <StreamingProvider>
+      <MapDataProvider> {/* Add Provider */}
+        <HeaderSearchButton />
       <div className="flex justify-start items-start">
         {/* This is the new div for scrolling */}
       <div className="w-1/2 flex flex-col space-y-3 md:space-y-4 px-8 sm:px-12 pt-12 md:pt-14 pb-4 h-[calc(100vh-0.5in)] overflow-y-auto">
@@ -145,6 +149,7 @@ export function Chat({ id }: ChatProps) {
           {activeView ? <SettingsView /> : <Mapbox />}
         </div>
       </div>
-    </MapDataProvider>
+      </MapDataProvider>
+    </StreamingProvider>
   );
 }

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -16,7 +16,6 @@ import { MapDataProvider, useMapData } from './map/map-data-context'; // Add thi
 import { updateDrawingContext } from '@/lib/actions/chat'; // Import the server action
 import dynamic from 'next/dynamic'
 import { HeaderSearchButton } from './header-search-button'
-import { StreamingProvider } from './streaming-context'
 
 type ChatProps = {
   id?: string // This is the chatId
@@ -85,9 +84,8 @@ export function Chat({ id }: ChatProps) {
   // Mobile layout
   if (isMobile) {
     return (
-      <StreamingProvider>
-        <MapDataProvider> {/* Add Provider */}
-          <HeaderSearchButton />
+      <MapDataProvider> {/* Add Provider */}
+        <HeaderSearchButton />
         <div className="mobile-layout-container">
           <div className="mobile-map-section">
           {activeView ? <SettingsView /> : <Mapbox />}
@@ -112,16 +110,14 @@ export function Chat({ id }: ChatProps) {
           )}
         </div>
         </div>
-        </MapDataProvider>
-      </StreamingProvider>
+      </MapDataProvider>
     );
   }
 
   // Desktop layout
   return (
-    <StreamingProvider>
-      <MapDataProvider> {/* Add Provider */}
-        <HeaderSearchButton />
+    <MapDataProvider> {/* Add Provider */}
+      <HeaderSearchButton />
       <div className="flex justify-start items-start">
         {/* This is the new div for scrolling */}
       <div className="w-1/2 flex flex-col space-y-3 md:space-y-4 px-8 sm:px-12 pt-12 md:pt-14 pb-4 h-[calc(100vh-0.5in)] overflow-y-auto">
@@ -149,7 +145,6 @@ export function Chat({ id }: ChatProps) {
           {activeView ? <SettingsView /> : <Mapbox />}
         </div>
       </div>
-      </MapDataProvider>
-    </StreamingProvider>
+    </MapDataProvider>
   );
 }

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -2,6 +2,7 @@
 import React from 'react'
 import Image from 'next/image'
 import { useCalendarToggle } from './calendar-toggle-context'
+import { useStreaming } from './streaming-context'
 import { ModeToggle } from './mode-toggle'
 import { cn } from '@/lib/utils'
 import HistoryContainer from './history-container'
@@ -18,6 +19,7 @@ import { ProfileToggle } from './profile-toggle'
 
 export const Header = () => {
   const { toggleCalendar } = useCalendarToggle()
+  const { isStreaming } = useStreaming()
   return (
     <header className="fixed w-full p-1 md:p-2 flex justify-between items-center z-10 backdrop-blur md:backdrop-blur-none bg-background/80 md:bg-transparent">
       <div>
@@ -28,7 +30,16 @@ export const Header = () => {
       
       <div className="absolute left-1">
         <Button variant="ghost" size="icon">
-          <Image src="/images/logo.svg" alt="Logo" width={24} height={24} className="h-6 w-auto" />
+          <Image 
+            src="/images/logo.svg" 
+            alt="Logo" 
+            width={24} 
+            height={24} 
+            className={cn(
+              "h-6 w-auto transition-transform duration-1000",
+              isStreaming && "animate-spin-ccw"
+            )} 
+          />
         </Button>
       </div>
       

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -7,9 +7,16 @@ import remarkGfm from 'remark-gfm'
 import remarkMath from 'remark-math'
 import rehypeKatex from 'rehype-katex'
 import 'katex/dist/katex.min.css'
+import { useStreaming } from './streaming-context'
+import { useEffect } from 'react'
 
 export function BotMessage({ content }: { content: StreamableValue<string> }) {
   const [data, error, pending] = useStreamableValue(content)
+  const { setIsStreaming } = useStreaming()
+
+  useEffect(() => {
+    setIsStreaming(pending)
+  }, [pending, setIsStreaming])
 
   // Currently, sometimes error occurs after finishing the stream.
   if (error) return <div>Error</div>

--- a/components/streaming-context.tsx
+++ b/components/streaming-context.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { createContext, useContext, useState, ReactNode } from 'react'
+
+interface StreamingContextType {
+  isStreaming: boolean
+  setIsStreaming: (streaming: boolean) => void
+}
+
+const StreamingContext = createContext<StreamingContextType | undefined>(undefined)
+
+export const useStreaming = () => {
+  const context = useContext(StreamingContext)
+  if (!context) {
+    throw new Error('useStreaming must be used within a StreamingProvider')
+  }
+  return context
+}
+
+export const StreamingProvider = ({ children }: { children: ReactNode }) => {
+  const [isStreaming, setIsStreaming] = useState(false)
+
+  return (
+    <StreamingContext.Provider value={{ isStreaming, setIsStreaming }}>
+      {children}
+    </StreamingContext.Provider>
+  )
+}

--- a/components/streaming-context.tsx
+++ b/components/streaming-context.tsx
@@ -12,7 +12,8 @@ const StreamingContext = createContext<StreamingContextType | undefined>(undefin
 export const useStreaming = () => {
   const context = useContext(StreamingContext)
   if (!context) {
-    throw new Error('useStreaming must be used within a StreamingProvider')
+    // Return default values if used outside provider (e.g., during SSR)
+    return { isStreaming: false, setIsStreaming: () => {} }
   }
   return context
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -68,10 +68,15 @@ const config = {
           from: { height: "var(--radix-accordion-content-height)" },
           to: { height: "0" },
         },
+        "spin-ccw": {
+          from: { transform: "rotate(0deg)" },
+          to: { transform: "rotate(-360deg)" },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
+        "spin-ccw": "spin-ccw 2s linear infinite",
       },
       fontFamily: {
         sans: ["var(--font-sans)", ...fontFamily.sans],


### PR DESCRIPTION
### **User description**
This PR implements a feature where the plant icon (logo.svg) in the header spins counter-clockwise whenever tokens are being generated in the system.

## Changes Made:
- Created a new `StreamingContext` to track token generation state across the application
- Updated the `BotMessage` component to set streaming state based on the `pending` flag from `useStreamableValue`
- Modified the `Header` component to apply a counter-clockwise spinning animation to the logo when streaming is active
- Added custom Tailwind CSS animation `animate-spin-ccw` that rotates the icon -360 degrees over 2 seconds
- Wrapped the `Chat` component with `StreamingProvider` to provide streaming context

## Technical Details:
- The animation is smooth and continuous while tokens are being generated
- The icon returns to its normal state when generation completes
- The implementation is efficient and doesn't impact performance


___

### **PR Type**
Enhancement


___

### **Description**
- Add counter-clockwise spinning animation to plant icon during token generation

- Create `StreamingContext` to track token generation state globally

- Update `BotMessage` component to sync streaming state with context

- Apply `animate-spin-ccw` animation to logo in header when streaming

- Define custom Tailwind animation rotating -360 degrees over 2 seconds


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["BotMessage<br/>pending state"] -->|"setIsStreaming"| B["StreamingContext<br/>isStreaming"]
  B -->|"useStreaming hook"| C["Header Component<br/>Logo Image"]
  C -->|"apply class"| D["animate-spin-ccw<br/>-360deg rotation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>streaming-context.tsx</strong><dd><code>Create streaming context for token generation tracking</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/streaming-context.tsx

<ul><li>Created new React Context to manage global streaming state<br> <li> Implemented <code>useStreaming</code> hook for accessing streaming state<br> <li> Implemented <code>StreamingProvider</code> component to wrap application<br> <li> Provides <code>isStreaming</code> boolean and <code>setIsStreaming</code> setter function</ul>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/357/files#diff-aaba02d13f20e121c34751d0a85cbafff7d6675325c8a55be3b7681c7cea9df8">+28/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>message.tsx</strong><dd><code>Sync BotMessage pending state to streaming context</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/message.tsx

<ul><li>Import <code>useStreaming</code> hook and <code>useEffect</code> from React<br> <li> Extract <code>pending</code> state from <code>useStreamableValue</code> hook<br> <li> Sync <code>pending</code> state to global streaming context via <code>setIsStreaming</code><br> <li> Update streaming state whenever <code>pending</code> changes</ul>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/357/files#diff-119f563915750907b6691f79e59a4486ae1d7e2dc99b18d0b6c425da66dc0a78">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>header.tsx</strong><dd><code>Apply spinning animation to logo when streaming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/header.tsx

<ul><li>Import <code>useStreaming</code> hook to access streaming state<br> <li> Get <code>isStreaming</code> value from streaming context<br> <li> Apply <code>animate-spin-ccw</code> class to logo image conditionally<br> <li> Add transition and duration classes for smooth animation</ul>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/357/files#diff-cf7e29e4902dea0aa000da86f34225ba6d7a6d13c982343f255b15f827269199">+12/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chat.tsx</strong><dd><code>Wrap Chat component with StreamingProvider</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/chat.tsx

<ul><li>Import <code>StreamingProvider</code> component<br> <li> Wrap both mobile and desktop layouts with <code>StreamingProvider</code><br> <li> Position <code>StreamingProvider</code> as outermost wrapper around <code>MapDataProvider</code><br> <li> Ensure streaming context is available to all child components</ul>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/357/files#diff-015689ed51facf46aa073450a0660cfa8b56e37b6b94248a56ec66550007f31b">+11/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tailwind.config.ts</strong><dd><code>Define counter-clockwise spin animation in Tailwind</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tailwind.config.ts

<ul><li>Add <code>spin-ccw</code> keyframe animation rotating from 0deg to -360deg<br> <li> Define <code>spin-ccw</code> animation class with 2s duration and linear timing<br> <li> Set animation to run infinitely while streaming is active</ul>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/357/files#diff-655dc9e3d0aa561e3fa164bf48bd89cb0f5da65e0a567f8ebbf9dd791a0e7f40">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added visual streaming indicator – the logo now spins with a counter-clockwise animation during active streaming operations, providing real-time feedback on processing status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->