### PR TITLE
Fix: Remove queue link from form definition

### DIFF
--- a/app/actions.tsx
+++ b/app/actions.tsx
@@ -135,9 +135,9 @@ async function submit(formData?: FormData, skip?: boolean) {
 
   if (userInput.toLowerCase().trim() === 'what is a planet computer?' || userInput.toLowerCase().trim() === 'what is qcx-terra?') {
     const definition = userInput.toLowerCase().trim() === 'what is a planet computer?'
-      ? `A planet computer is a proprietary environment aware system that interoperates weather forecasting, mapping and scheduling using cutting edge multi-agents to streamline automation and exploration on a planet. Available for our Pro and Enterprise customers. [QCX Pricing](https://www.queue.cx/#pricing)`
+      ? `A planet computer is a proprietary environment aware system that interoperates weather forecasting, mapping and scheduling using cutting edge multi-agents to streamline automation and exploration on a planet. Available for our Pro and Enterprise customers.`
 
-      : `QCX-Terra is a model garden of pixel level precision geospatial foundational models for efficient land feature predictions from satellite imagery. Available for our Pro and Enterprise customers. [QCX Pricing] (https://www.queue.cx/#pricing)`;
+      : `QCX-Terra is a model garden of pixel level precision geospatial foundational models for efficient land feature predictions from satellite imagery. Available for our Pro and Enterprise customers.`;
 
     const content = JSON.stringify(Object.fromEntries(formData!));
     const type = 'input';


### PR DESCRIPTION
### **User description**
This PR removes the hardcoded link to the queue pricing page from the 'what is a planet computer?' and 'what is qcx-terra?' definitions in `app/actions.tsx`. This ensures the form opens directly without the link being present, as requested.


___

### **PR Type**
Bug fix


___

### **Description**
- Remove hardcoded QCX Pricing links from form definitions

- Clean up planet computer and QCX-Terra description text

- Simplify user-facing definition strings in actions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Form Definitions"] -->|Remove Links| B["Clean Descriptions"]
  B -->|Planet Computer| C["Definition without URL"]
  B -->|QCX-Terra| D["Definition without URL"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>actions.tsx</strong><dd><code>Remove pricing links from form definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/actions.tsx

<ul><li>Removed <code>[QCX Pricing](https://www.queue.cx/#pricing)</code> link from planet <br>computer definition<br> <li> Removed <code>[QCX Pricing] (https://www.queue.cx/#pricing)</code> link from <br>QCX-Terra definition<br> <li> Simplified both form response strings to contain only descriptive text</ul>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/365/files#diff-5d789135759f172b94f5f9b4c62ad9f1410b79f4c8cff86ffed6464f22b61752">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed pricing references from help text for specific queries, providing more streamlined definitions that focus on core descriptions rather than pricing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->