### PR TITLE
feat: Add Gemini 3 Pro model support

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -7,6 +7,10 @@ SMITHERY_API_KEY="your_smithery_api_key_here"
 # Ensure it's also in your .env.local file if you haven't set it up yet.
 # NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN="your_mapbox_public_token_here"
 
+# AI Provider API Keys
+# Gemini 3 Pro (Google Generative AI)
+GEMINI_3_PRO_API_KEY="your_gemini_3_pro_api_key_here"
+
 # Supabase Credentials
 NEXT_PUBLIC_SUPABASE_URL="YOUR_SUPABASE_URL_HERE"
 NEXT_PUBLIC_SUPABASE_ANON_KEY="YOUR_SUPABASE_ANON_KEY_HERE"

--- a/GEMINI_3_PRO_INTEGRATION.md
+++ b/GEMINI_3_PRO_INTEGRATION.md
@@ -1,0 +1,81 @@
+# Gemini 3 Pro Integration
+
+## Overview
+
+This document describes the integration of Google's Gemini 3 Pro model into the QCX application. Gemini 3 Pro is Google's most advanced reasoning model with state-of-the-art capabilities for multimodal understanding, coding, and agentic tasks.
+
+## Changes Made
+
+### 1. Updated `lib/utils/index.ts`
+
+Added Gemini 3 Pro as a provider option in the `getModel()` function with the following priority order:
+
+1. **xAI (Grok)** - Primary choice if `XAI_API_KEY` is configured
+2. **Gemini 3 Pro** - Secondary choice if `GEMINI_3_PRO_API_KEY` is configured *(NEW)*
+3. **AWS Bedrock** - Tertiary choice if AWS credentials are configured
+4. **OpenAI** - Default fallback if `OPENAI_API_KEY` is configured
+
+The implementation includes:
+- Environment variable check for `GEMINI_3_PRO_API_KEY`
+- Creation of Google Generative AI client using `createGoogleGenerativeAI()`
+- Model identifier: `gemini-3-pro-preview`
+- Error handling with fallback to the next available provider
+
+### 2. Updated `.env.local.example`
+
+Added documentation for the new environment variable:
+
+```bash
+# AI Provider API Keys
+# Gemini 3 Pro (Google Generative AI)
+GEMINI_3_PRO_API_KEY="your_gemini_3_pro_api_key_here"
+```
+
+## Configuration
+
+To use Gemini 3 Pro in your QCX deployment:
+
+1. Obtain a Google AI API key from [Google AI Studio](https://aistudio.google.com/)
+2. Add the API key to your `.env.local` file:
+   ```bash
+   GEMINI_3_PRO_API_KEY="your_actual_api_key_here"
+   ```
+3. Restart your development server or redeploy your application
+
+## Model Capabilities
+
+Gemini 3 Pro (`gemini-3-pro-preview`) supports:
+
+- **Advanced Reasoning**: State-of-the-art reasoning capabilities with optional thinking modes
+- **Multimodal Understanding**: Text, image, and file inputs
+- **Tool Usage**: Function calling and tool integration
+- **Large Context Window**: 1M token context window
+- **Agentic Capabilities**: Excellent for complex multi-step tasks
+- **Coding**: Exceptional coding and technical capabilities
+
+## Provider Priority
+
+The provider selection follows this priority order:
+
+```
+XAI_API_KEY exists? → Use Grok
+  ↓ No
+GEMINI_3_PRO_API_KEY exists? → Use Gemini 3 Pro
+  ↓ No
+AWS credentials exist? → Use AWS Bedrock
+  ↓ No
+OPENAI_API_KEY exists? → Use OpenAI (default)
+```
+
+## Technical Details
+
+- **SDK Package**: `@ai-sdk/google` (already imported in the codebase)
+- **Model ID**: `gemini-3-pro-preview`
+- **API Endpoint**: Google Generative AI API
+- **Vercel AI SDK Compatible**: Yes, fully compatible with the unified interface
+
+## References
+
+- [Google Gemini 3 Documentation](https://ai.google.dev/gemini-api/docs/gemini-3)
+- [Vercel AI SDK - Google Provider](https://ai-sdk.dev/providers/ai-sdk-providers/google-generative-ai)
+- [Google AI Studio](https://aistudio.google.com/)

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -18,6 +18,7 @@ export function generateUUID(): string {
 
 export function getModel() {
   const xaiApiKey = process.env.XAI_API_KEY
+  const gemini3ProApiKey = process.env.GEMINI_3_PRO_API_KEY
   const awsAccessKeyId = process.env.AWS_ACCESS_KEY_ID
   const awsSecretAccessKey = process.env.AWS_SECRET_ACCESS_KEY
   const awsRegion = process.env.AWS_REGION
@@ -33,6 +34,18 @@ export function getModel() {
       return xai('grok-4-fast-non-reasoning')
     } catch (error) {
       console.warn('xAI API unavailable, falling back to OpenAI:')
+    }
+  }
+
+  // Gemini 3 Pro
+  if (gemini3ProApiKey) {
+    const google = createGoogleGenerativeAI({
+      apiKey: gemini3ProApiKey,
+    })
+    try {
+      return google('gemini-3-pro-preview')
+    } catch (error) {
+      console.warn('Gemini 3 Pro API unavailable, falling back to next provider:', error)
     }
   }
 


### PR DESCRIPTION
### **User description**
## Overview

This PR adds support for Google's Gemini 3 Pro model to the QCX application, allowing users to leverage Google's most advanced reasoning model with state-of-the-art multimodal understanding and agentic capabilities.

## Changes

### 1. Updated `lib/utils/index.ts`
- Added Gemini 3 Pro as a provider option in the `getModel()` function
- Positioned as secondary choice (after xAI, before AWS Bedrock)
- Uses `gemini-3-pro-preview` model identifier
- Includes proper error handling with fallback to next available provider
- Reads from `GEMINI_3_PRO_API_KEY` environment variable

### 2. Updated `.env.local.example`
- Added documentation for the new `GEMINI_3_PRO_API_KEY` environment variable
- Included clear instructions for users to configure their API key

### 3. Added `GEMINI_3_PRO_INTEGRATION.md`
- Comprehensive documentation of the integration
- Configuration instructions
- Model capabilities overview
- Provider priority explanation
- Technical details and references

## Provider Priority Order

After this change, the provider selection follows this order:

1. **xAI (Grok)** - if `XAI_API_KEY` is set
2. **Gemini 3 Pro** - if `GEMINI_3_PRO_API_KEY` is set *(NEW)*
3. **AWS Bedrock** - if AWS credentials are set
4. **OpenAI** - default fallback

## Model Capabilities

Gemini 3 Pro (`gemini-3-pro-preview`) provides:
- Advanced reasoning with optional thinking modes
- Multimodal understanding (text, image, file inputs)
- Tool usage and function calling
- 1M token context window
- Exceptional coding and agentic capabilities

## Configuration

Users can enable Gemini 3 Pro by adding to their `.env.local`:

```bash
GEMINI_3_PRO_API_KEY="your_api_key_here"
```

API keys can be obtained from [Google AI Studio](https://aistudio.google.com/).

## Testing

- ✅ Code compiles without errors
- ✅ Follows existing provider pattern (xAI, Bedrock, OpenAI)
- ✅ Includes error handling and fallback logic
- ✅ SDK already imported in codebase (`@ai-sdk/google`)
- ✅ Compatible with Vercel AI SDK unified interface

## References

- [Google Gemini 3 Documentation](https://ai.google.dev/gemini-api/docs/gemini-3)
- [Vercel AI SDK - Google Provider](https://ai-sdk.dev/providers/ai-sdk-providers/google-generative-ai)
- [Google AI Studio](https://aistudio.google.com/)

## Related Issues

Resolves the request to add Gemini 3 Pro support with `GEMINI_3_PRO_API_KEY` environment variable.


___

### **PR Type**
Enhancement


___

### **Description**
- Adds Gemini 3 Pro as secondary AI provider option

- Implements provider fallback chain with proper error handling

- Configures environment variable for API key management

- Includes comprehensive integration documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["getModel() function"] --> B{"XAI_API_KEY set?"}
  B -->|Yes| C["Use Grok"]
  B -->|No| D{"GEMINI_3_PRO_API_KEY set?"}
  D -->|Yes| E["Use Gemini 3 Pro"]
  D -->|No| F{"AWS credentials set?"}
  F -->|Yes| G["Use AWS Bedrock"]
  F -->|No| H["Use OpenAI"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Integrate Gemini 3 Pro into provider selection logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/utils/index.ts

<ul><li>Added <code>GEMINI_3_PRO_API_KEY</code> environment variable check<br> <li> Implemented Gemini 3 Pro provider initialization using <br><code>createGoogleGenerativeAI()</code><br> <li> Positioned as secondary provider after xAI, before AWS Bedrock<br> <li> Includes error handling with fallback to next available provider</ul>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/389/files#diff-76051e819bd9ea2a35405d89d3fbf1831f45019a2b12d5e0a915668d1bd46462">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.env.local.example</strong><dd><code>Document Gemini 3 Pro API key configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.env.local.example

<ul><li>Added <code>GEMINI_3_PRO_API_KEY</code> environment variable documentation<br> <li> Organized AI provider API keys section with clear comments<br> <li> Provided example format for users to configure the API key</ul>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/389/files#diff-51db1e9260201708554a6d042039c4cd3366a090e6d2c3c59f281b22740dc7d6">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>GEMINI_3_PRO_INTEGRATION.md</strong><dd><code>Add Gemini 3 Pro integration documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

GEMINI_3_PRO_INTEGRATION.md

<ul><li>Created comprehensive integration guide for Gemini 3 Pro<br> <li> Documented provider priority order and selection logic<br> <li> Included configuration instructions and model capabilities overview<br> <li> Provided technical details, references, and setup steps</ul>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/389/files#diff-0a8343c95f022377bc0f5686e8019dc250eecce4b6700095a245c8dfc53fe12a">+81/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gemini 3 Pro as a new AI provider option with automatic fallback support.
  * New API key configuration available for Gemini 3 Pro integration.

* **Documentation**
  * Updated configuration documentation to include setup instructions for the new provider.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->