### PR TITLE
Add Mapbox Compare Slider to Drawing Mode

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -61,6 +61,7 @@
         "lottie-react": "^2.4.1",
         "lucide-react": "^0.507.0",
         "mapbox-gl": "^3.11.0",
+        "mapbox-gl-compare": "^0.4.2",
         "next": "15.3.6",
         "next-themes": "^0.3.0",
         "open-codex": "^0.1.30",
@@ -384,6 +385,8 @@
     "@mapbox/mapbox-gl-draw": ["@mapbox/mapbox-gl-draw@1.5.1", "", { "dependencies": { "@mapbox/geojson-area": "^0.2.2", "@mapbox/geojson-normalize": "^0.0.1", "@mapbox/point-geometry": "^1.1.0", "@turf/projection": "^7.2.0", "fast-deep-equal": "^3.1.3", "nanoid": "^5.0.9" } }, "sha512-DnR/oarZVoIrVHssAn+mtpuGzYH+ebORoPjow46zTBNPod/HQnvIZGtL6hIb5BVWxxH49RC9D20ipxiO9WDRxA=="],
 
     "@mapbox/mapbox-gl-supported": ["@mapbox/mapbox-gl-supported@3.0.0", "", {}, "sha512-2XghOwu16ZwPJLOFVuIOaLbN0iKMn867evzXFyf0P22dqugezfJwLmdanAgU25ITvz1TvOfVP4jsDImlDJzcWg=="],
+
+    "@mapbox/mapbox-gl-sync-move": ["@mapbox/mapbox-gl-sync-move@0.3.1", "", {}, "sha512-Y3PMyj0m/TBJa9OkQnO2TiVDu8sFUPmLF7q/THUHrD/g42qrURpMJJ4kufq4sR60YFMwZdCGBshrbgK5v2xXWw=="],
 
     "@mapbox/point-geometry": ["@mapbox/point-geometry@1.1.0", "", {}, "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ=="],
 
@@ -1788,6 +1791,8 @@
     "makeerror": ["makeerror@1.0.12", "", { "dependencies": { "tmpl": "1.0.5" } }, "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg=="],
 
     "mapbox-gl": ["mapbox-gl@3.17.0", "", { "dependencies": { "@mapbox/jsonlint-lines-primitives": "^2.0.2", "@mapbox/mapbox-gl-supported": "^3.0.0", "@mapbox/point-geometry": "^1.1.0", "@mapbox/tiny-sdf": "^2.0.6", "@mapbox/unitbezier": "^0.0.1", "@mapbox/vector-tile": "^2.0.4", "@mapbox/whoots-js": "^3.1.0", "@types/geojson": "^7946.0.16", "@types/geojson-vt": "^3.2.5", "@types/mapbox__point-geometry": "^0.1.4", "@types/pbf": "^3.0.5", "@types/supercluster": "^7.1.3", "cheap-ruler": "^4.0.0", "csscolorparser": "~1.0.3", "earcut": "^3.0.1", "geojson-vt": "^4.0.2", "gl-matrix": "^3.4.4", "grid-index": "^1.1.0", "kdbush": "^4.0.2", "martinez-polygon-clipping": "^0.7.4", "murmurhash-js": "^1.0.0", "pbf": "^4.0.1", "potpack": "^2.0.0", "quickselect": "^3.0.0", "supercluster": "^8.0.1", "tinyqueue": "^3.0.0" } }, "sha512-nCrDKRlr5di6xUksUDslNWwxroJ5yv1hT8pyVFtcpWJOOKsYQxF/wOFTMie8oxMnXeFkrz1Tl1TwA1XN1yX0KA=="],
+
+    "mapbox-gl-compare": ["mapbox-gl-compare@0.4.2", "", { "dependencies": { "@mapbox/mapbox-gl-sync-move": "^0.3.1" } }, "sha512-MhKUYJri3KIfeB2rsLUh2JzPutdfehU3vqdfgp2+uocKjNYQwCUvQ0T8u7fBwIJvJKdfWg3FiDq+5oZC4AtAGg=="],
 
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
 

--- a/components/map/mapbox-map.tsx
+++ b/components/map/mapbox-map.tsx
@@ -1,10 +1,16 @@
 'use client'
 
-import { useEffect, useRef, useCallback, useState } from 'react' // Removed useState
+import { useEffect, useRef, useCallback, useState } from 'react'
 import mapboxgl from 'mapbox-gl'
-import Compare from 'mapbox-gl-compare'
 import 'mapbox-gl-compare/dist/mapbox-gl-compare.css'
+import type CompareClass from 'mapbox-gl-compare'
 import MapboxDraw from '@mapbox/mapbox-gl-draw'
+
+// Late-import mapbox-gl-compare to avoid SSR issues
+let Compare: any = null;
+if (typeof window !== 'undefined') {
+  Compare = require('mapbox-gl-compare');
+}
 import * as turf from '@turf/turf'
 import { toast } from 'react-toastify'
 import 'react-toastify/dist/ReactToastify.css'
@@ -22,7 +28,7 @@ export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number
   const afterMapContainer = useRef<HTMLDivElement>(null)
   const map = useRef<mapboxgl.Map | null>(null)
   const afterMap = useRef<mapboxgl.Map | null>(null)
-  const compareRef = useRef<Compare | null>(null)
+  const compareRef = useRef<CompareClass | null>(null)
   const afterMapMarkersRef = useRef<mapboxgl.Marker[]>([])
   const { setMap } = useMap()
   const drawRef = useRef<MapboxDraw | null>(null)
@@ -820,7 +826,7 @@ export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number
     <div className="relative h-full w-full overflow-hidden rounded-l-lg" id="comparison-container">
       <div
         ref={mapContainer}
-        className="absolute top-0 bottom-0 w-full"
+        className="absolute inset-0"
         onMouseDown={handleMouseDown}
         onMouseUp={handleMouseUp}
         onMouseLeave={handleMouseUp}
@@ -828,7 +834,7 @@ export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number
       {mapType === MapToggleEnum.DrawingMode && (
         <div
           ref={afterMapContainer}
-          className="absolute top-0 bottom-0 w-full pointer-events-none"
+          className="absolute inset-0 pointer-events-none"
         />
       )}
     </div>

--- a/components/map/mapbox-map.tsx
+++ b/components/map/mapbox-map.tsx
@@ -1,7 +1,9 @@
 'use client'
 
-import { useEffect, useRef, useCallback } from 'react' // Removed useState
+import { useEffect, useRef, useCallback, useState } from 'react' // Removed useState
 import mapboxgl from 'mapbox-gl'
+import Compare from 'mapbox-gl-compare'
+import 'mapbox-gl-compare/dist/mapbox-gl-compare.css'
 import MapboxDraw from '@mapbox/mapbox-gl-draw'
 import * as turf from '@turf/turf'
 import { toast } from 'react-toastify'
@@ -17,7 +19,11 @@ mapboxgl.accessToken = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN as string;
 
 export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number; } }> = ({ position }) => {
   const mapContainer = useRef<HTMLDivElement>(null)
+  const afterMapContainer = useRef<HTMLDivElement>(null)
   const map = useRef<mapboxgl.Map | null>(null)
+  const afterMap = useRef<mapboxgl.Map | null>(null)
+  const compareRef = useRef<Compare | null>(null)
+  const afterMapMarkersRef = useRef<mapboxgl.Marker[]>([])
   const { setMap } = useMap()
   const drawRef = useRef<MapboxDraw | null>(null)
   const rotationFrameRef = useRef<number | null>(null)
@@ -61,6 +67,107 @@ export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number
   }, [])
 
   // Create measurement labels for all features
+  const syncDrawingsToAfterMap = useCallback(() => {
+    if (!afterMap.current || !afterMap.current.getSource('draw-mirror')) return;
+
+    const source = afterMap.current.getSource('draw-mirror') as mapboxgl.GeoJSONSource;
+    const features = mapData.drawnFeatures?.map(df => df.geometry) || [];
+
+    source.setData({
+      type: 'FeatureCollection',
+      features: features.map((g, i) => ({
+        type: 'Feature',
+        geometry: g,
+        properties: mapData.drawnFeatures?.[i] || {}
+      }))
+    });
+
+    // Mirror labels
+    afterMapMarkersRef.current.forEach(m => m.remove());
+    afterMapMarkersRef.current = [];
+
+    mapData.drawnFeatures?.forEach(feature => {
+      let coords: [number, number] | null = null;
+      if (feature.type === 'Polygon') {
+        const centroid = turf.centroid(feature.geometry);
+        coords = centroid.geometry.coordinates as [number, number];
+      } else if (feature.type === 'LineString') {
+        const line = feature.geometry.coordinates;
+        const midIndex = Math.floor(line.length / 2) - 1;
+        coords = (midIndex >= 0 ? line[midIndex] : line[0]) as [number, number];
+      }
+
+      if (coords && afterMap.current) {
+        const el = document.createElement('div');
+        el.className = feature.type === 'Polygon' ? 'area-label' : 'distance-label';
+        el.style.background = 'rgba(255, 255, 255, 0.8)'
+        el.style.padding = '4px 8px'
+        el.style.borderRadius = '4px'
+        el.style.fontSize = '12px'
+        el.style.fontWeight = 'bold'
+        el.style.color = '#333333'
+        el.style.boxShadow = '0 2px 4px rgba(0,0,0,0.2)'
+        el.style.pointerEvents = 'none'
+        el.textContent = feature.measurement;
+
+        const marker = new mapboxgl.Marker({ element: el })
+          .setLngLat(coords)
+          .addTo(afterMap.current);
+        afterMapMarkersRef.current.push(marker);
+      }
+    });
+  }, [mapData.drawnFeatures]);
+
+  const setupAfterMapLayers = useCallback(() => {
+    if (!afterMap.current) return;
+
+    // Add source for mirrored drawings
+    afterMap.current.addSource('draw-mirror', {
+      type: 'geojson',
+      data: {
+        type: 'FeatureCollection',
+        features: []
+      }
+    });
+
+    // Add layers for polygons and lines
+    afterMap.current.addLayer({
+      id: 'draw-mirror-polygons',
+      type: 'fill',
+      source: 'draw-mirror',
+      filter: ['==', '$type', 'Polygon'],
+      paint: {
+        'fill-color': '#fbb03b',
+        'fill-opacity': 0.1
+      }
+    });
+
+    afterMap.current.addLayer({
+      id: 'draw-mirror-polygons-outline',
+      type: 'line',
+      source: 'draw-mirror',
+      filter: ['==', '$type', 'Polygon'],
+      paint: {
+        'line-color': '#fbb03b',
+        'line-width': 2
+      }
+    });
+
+    afterMap.current.addLayer({
+      id: 'draw-mirror-lines',
+      type: 'line',
+      source: 'draw-mirror',
+      filter: ['==', '$type', 'LineString'],
+      paint: {
+        'line-color': '#fbb03b',
+        'line-width': 2
+      }
+    });
+
+    // Initial sync
+    syncDrawingsToAfterMap();
+  }, [syncDrawingsToAfterMap]);
+
   const updateMeasurementLabels = useCallback(() => {
     if (!map.current || !drawRef.current) return
 
@@ -335,6 +442,71 @@ export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number
     }
   }, [setMapData])
 
+  // Handle comparison map initialization
+  useEffect(() => {
+    if (mapType === MapToggleEnum.DrawingMode && map.current && afterMapContainer.current && !afterMap.current) {
+      const center = map.current.getCenter();
+      const zoom = map.current.getZoom();
+      const pitch = map.current.getPitch();
+      const bearing = map.current.getBearing();
+
+      afterMap.current = new mapboxgl.Map({
+        container: afterMapContainer.current,
+        style: 'mapbox://styles/mapbox/streets-v12',
+        center: [center.lng, center.lat],
+        zoom: zoom,
+        pitch: pitch,
+        bearing: bearing,
+        maxZoom: 22,
+        attributionControl: false,
+      });
+
+      afterMap.current.on('load', () => {
+        if (!map.current || !afterMap.current || !afterMapContainer.current?.parentElement) return;
+
+        // Create the compare control
+        compareRef.current = new Compare(
+          map.current,
+          afterMap.current,
+          afterMapContainer.current.parentElement,
+          {
+            orientation: 'vertical',
+            mousemove: false
+          }
+        );
+
+        // Setup layers on afterMap
+        setupAfterMapLayers();
+      });
+    }
+
+    // Cleanup when leaving DrawingMode
+    if (mapType !== MapToggleEnum.DrawingMode) {
+      if (compareRef.current) {
+        compareRef.current.remove();
+        compareRef.current = null;
+      }
+      if (afterMap.current) {
+        afterMap.current.remove();
+        afterMap.current = null;
+      }
+      afterMapMarkersRef.current.forEach(m => m.remove());
+      afterMapMarkersRef.current = [];
+
+      if (map.current) {
+        const container = map.current.getContainer();
+        if (container) container.style.clip = '';
+      }
+    }
+  }, [mapType, setupAfterMapLayers]);
+
+  // Effect to sync drawings when they change
+  useEffect(() => {
+    if (mapType === MapToggleEnum.DrawingMode) {
+      syncDrawingsToAfterMap();
+    }
+  }, [mapData.drawnFeatures, mapType, syncDrawingsToAfterMap]);
+
   // Set up idle rotation checker
   useEffect(() => {
     const checkIdle = setInterval(() => {
@@ -510,6 +682,18 @@ export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number
         stopRotation()
         setIsMapLoaded(false) // Reset map loaded state on cleanup
         setMap(null) // Clear map instance from context
+
+        if (compareRef.current) {
+          compareRef.current.remove()
+          compareRef.current = null
+        }
+        if (afterMap.current) {
+          afterMap.current.remove()
+          afterMap.current = null
+        }
+        afterMapMarkersRef.current.forEach(m => m.remove());
+        afterMapMarkersRef.current = [];
+
         map.current.remove()
         map.current = null
       }
@@ -633,14 +817,20 @@ export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number
 
 
   return (
-    <div className="relative h-full w-full">
+    <div className="relative h-full w-full overflow-hidden rounded-l-lg" id="comparison-container">
       <div
         ref={mapContainer}
-        className="h-full w-full overflow-hidden rounded-l-lg"
+        className="absolute top-0 bottom-0 w-full"
         onMouseDown={handleMouseDown}
         onMouseUp={handleMouseUp}
-        onMouseLeave={handleMouseUp} // Clear timer if mouse leaves container while pressed
+        onMouseLeave={handleMouseUp}
       />
+      {mapType === MapToggleEnum.DrawingMode && (
+        <div
+          ref={afterMapContainer}
+          className="absolute top-0 bottom-0 w-full pointer-events-none"
+        />
+      )}
     </div>
   )
 }

--- a/lib/types/mapbox-gl-compare.d.ts
+++ b/lib/types/mapbox-gl-compare.d.ts
@@ -1,0 +1,21 @@
+declare module 'mapbox-gl-compare' {
+  import { Map } from 'mapbox-gl';
+
+  export interface CompareOptions {
+    orientation?: 'vertical' | 'horizontal';
+    mousemove?: boolean;
+  }
+
+  export default class Compare {
+    constructor(
+      a: Map,
+      b: Map,
+      container: string | HTMLElement,
+      options?: CompareOptions
+    );
+    remove(): void;
+    on(type: string, fn: Function): this;
+    off(type: string, fn: Function): this;
+    setSlider(x: number): void;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "lottie-react": "^2.4.1",
     "lucide-react": "^0.507.0",
     "mapbox-gl": "^3.11.0",
+    "mapbox-gl-compare": "^0.4.2",
     "next": "15.3.6",
     "next-themes": "^0.3.0",
     "open-codex": "^0.1.30",


### PR DESCRIPTION
### **User description**
This change implements a Mapbox split-screen comparison slider that activates specifically when the user enters Drawing Mode. It allows comparing the default Satellite Streets view with a standard Streets view while keeping all drawings, measurements, and labels perfectly synced on both sides.

---
*PR created automatically by Jules for task [11900621403850848071](https://jules.google.com/task/11900621403850848071) started by @ngoiyaeric*


___

### **PR Type**
Enhancement


___

### **Description**
- Adds Mapbox split-screen comparison slider for Drawing Mode

- Implements dual map synchronization with Streets view

- Mirrors drawn geometries and measurement labels on comparison map

- Automatically activates/deactivates slider when entering/exiting Drawing Mode


___

### Diagram Walkthrough


```mermaid
flowchart LR
  DrawingMode["Drawing Mode Activated"]
  CreateMap["Create Comparison Map<br/>Streets Style"]
  SyncLayers["Setup Mirror Layers<br/>for Drawings"]
  CompareSlider["Initialize Compare<br/>Slider Control"]
  SyncDrawings["Sync Drawn Features<br/>& Labels"]
  Cleanup["Cleanup on Exit<br/>Drawing Mode"]
  
  DrawingMode --> CreateMap
  CreateMap --> SyncLayers
  SyncLayers --> CompareSlider
  CompareSlider --> SyncDrawings
  SyncDrawings --> Cleanup
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mapbox-gl-compare.d.ts</strong><dd><code>Add mapbox-gl-compare TypeScript type definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/types/mapbox-gl-compare.d.ts

<ul><li>Created TypeScript type declarations for mapbox-gl-compare library<br> <li> Defined Compare class interface with constructor and methods<br> <li> Specified CompareOptions interface for orientation and mousemove <br>settings</ul>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/454/files#diff-692974335f1d55d537d50bcde0f500ace506508957cc0fe6aafd47dda200cbf5">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add mapbox-gl-compare package dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

- Added mapbox-gl-compare dependency version ^0.4.2


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/454/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mapbox-map.tsx</strong><dd><code>Implement dual map synchronization and comparison slider</code>&nbsp; </dd></summary>
<hr>

components/map/mapbox-map.tsx

<ul><li>Added useState import and mapbox-gl-compare library integration<br> <li> Created refs for comparison map, markers, and compare control<br> <li> Implemented syncDrawingsToAfterMap function to mirror geometries and <br>labels<br> <li> Added setupAfterMapLayers to create GeoJSON source and styling layers<br> <li> Added useEffect hook to initialize/cleanup comparison map on Drawing <br>Mode toggle<br> <li> Added useEffect to sync drawn features when mapData changes<br> <li> Updated JSX to include afterMapContainer div for comparison map <br>rendering<br> <li> Enhanced cleanup logic to properly remove comparison map and markers</ul>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/454/files#diff-ce7ea3ef85a6812c7da39941ffa47e8e0fadbb3fc7c391cf1cafd96303cf3a0f">+194/-4</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Side-by-side map comparison with an interactive slider available in Drawing Mode.
  * Real-time sync of drawings and measurements between main and comparison maps.
  * Dynamic labels for areas and distances displayed in the comparison view.
  * Comparison panel integrates with existing drawing tools and toggles cleanly with mode changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->