### PR TITLE
Conditional Map Zoom Controls and Mode Transition Fix

### DIFF
--- a/components/map/mapbox-map.tsx
+++ b/components/map/mapbox-map.tsx
@@ -21,6 +21,7 @@ export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number
   const map = useRef<mapboxgl.Map | null>(null)
   const { setMap } = useMap()
   const drawRef = useRef<MapboxDraw | null>(null)
+  const navControlRef = useRef<mapboxgl.NavigationControl | null>(null)
   const rotationFrameRef = useRef<number | null>(null)
   const polygonLabelsRef = useRef<{ [id: string]: mapboxgl.Marker }>({})
   const lineLabelsRef = useRef<{ [id: string]: mapboxgl.Marker }>({})
@@ -257,6 +258,16 @@ export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number
         console.log('Error removing draw control:', e)
       }
     }
+
+    // Remove existing navigation control if present
+    if (navControlRef.current) {
+      try {
+        map.current.removeControl(navControlRef.current)
+        navControlRef.current = null
+      } catch (e) {
+        console.log('Error removing navigation control:', e)
+      }
+    }
     
     // Create new draw control with both polygon and line tools
     drawRef.current = new MapboxDraw({
@@ -272,6 +283,12 @@ export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number
     
     // Add control to map
     map.current.addControl(drawRef.current, 'top-right')
+
+    // Add navigation control only on desktop
+    if (window.innerWidth > 768) {
+      navControlRef.current = new mapboxgl.NavigationControl()
+      map.current.addControl(navControlRef.current, 'top-left')
+    }
     
     // Set up event listeners for measurements
     map.current.on('draw.create', updateMeasurementLabels)
@@ -388,10 +405,6 @@ export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number
         preserveDrawingBuffer: true
       })
 
-      if (window.innerWidth > 768) {
-        map.current.addControl(new mapboxgl.NavigationControl(), 'top-left')
-      }
-
       // Register event listeners
       map.current.on('moveend', captureMapCenter)
       map.current.on('mousedown', handleUserInteraction)
@@ -459,14 +472,15 @@ export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number
   // Handle map mode changes
   useEffect(() => {
     // Store previous map type to detect changes
-    const isMapTypeChanged = previousMapTypeRef.current !== mapType
-    previousMapTypeRef.current = mapType
+    const prevMapType = previousMapTypeRef.current
+    const isMapTypeChanged = prevMapType !== mapType
 
     // Only proceed if map is initialized
     if (!map.current || !isMapReady) return
 
     // If we're switching modes
     if (isMapTypeChanged) {
+      previousMapTypeRef.current = mapType
       captureMapCenter()
 
       // Stop current mode-specific activities
@@ -486,7 +500,7 @@ export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number
       }
 
       // Cleanup drawing tools if switching AWAY from drawing mode
-      if (previousMapTypeRef.current === MapToggleEnum.DrawingMode && mapType !== MapToggleEnum.DrawingMode) {
+      if (prevMapType === MapToggleEnum.DrawingMode && mapType !== MapToggleEnum.DrawingMode) {
         if (drawRef.current) {
           // Save current drawings before removing control
           drawingFeatures.current = drawRef.current.getAll()
@@ -505,6 +519,16 @@ export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number
             lineLabelsRef.current = {}
           } catch (e) {
             console.log('Error removing draw control:', e)
+          }
+        }
+
+        // Also remove navigation control when leaving drawing mode
+        if (navControlRef.current) {
+          try {
+            map.current.removeControl(navControlRef.current)
+            navControlRef.current = null
+          } catch (e) {
+            console.log('Error removing navigation control:', e)
           }
         }
       }

--- a/tests/map.spec.ts
+++ b/tests/map.spec.ts
@@ -35,6 +35,11 @@ test.describe('Map functionality', () => {
       return;
     }
 
+    // Zoom controls are now only visible in Drawing Mode on desktop
+    await page.click('[data-testid="map-toggle"]');
+    await page.click('[data-testid="map-mode-draw"]');
+    await expect(page.locator('.mapboxgl-ctrl-zoom-in')).toBeVisible();
+
     const hasMap = await page.evaluate(() => Boolean((window as any).map));
     if (!hasMap) test.skip(true, 'Map instance not available on window for E2E');
 


### PR DESCRIPTION
### **User description**
This PR implements conditional visibility for Mapbox zoom controls (NavigationControl). They are now only added to the map when the user enters 'Drawing & Measure' mode on desktop devices (>768px). They are automatically removed when switching to other modes. 

Additionally, this PR fixes a bug in the mode transition logic in `mapbox-map.tsx` where the `previousMapTypeRef` was being updated at the beginning of the effect, which made the subsequent cleanup check `prevMapType === DrawingMode && mapType !== DrawingMode` impossible to satisfy. The logic now correctly captures the previous state before updating the ref.

---
*PR created automatically by Jules for task [2225694765400062008](https://jules.google.com/task/2225694765400062008) started by @ngoiyaeric*


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add conditional zoom controls visibility in Drawing Mode only

- Fix mode transition logic to correctly detect mode changes

- Remove navigation control when exiting Drawing Mode

- Update E2E tests to verify zoom controls in Drawing Mode


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Map Initialization"] -->|"Desktop Only"| B["Add Navigation Control"]
  C["Enter Drawing Mode"] -->|"Setup"| D["Add Navigation Control"]
  E["Exit Drawing Mode"] -->|"Cleanup"| F["Remove Navigation Control"]
  G["Mode Change Detected"] -->|"Fixed Logic"| H["Correct Cleanup Execution"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement, bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mapbox-map.tsx</strong><dd><code>Conditional navigation control and mode transition fix</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/map/mapbox-map.tsx

<ul><li>Added <code>navControlRef</code> to track navigation control instance<br> <li> Moved navigation control creation from map initialization to Drawing <br>Mode setup<br> <li> Added navigation control removal when exiting Drawing Mode<br> <li> Fixed mode transition logic by capturing previous state before <br>updating ref<br> <li> Updated cleanup logic to use captured <code>prevMapType</code> instead of ref</ul>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/482/files#diff-ce7ea3ef85a6812c7da39941ffa47e8e0fadbb3fc7c391cf1cafd96303cf3a0f">+31/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>map.spec.ts</strong><dd><code>Update zoom control test for Drawing Mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/map.spec.ts

<ul><li>Added navigation to Drawing Mode before verifying zoom control <br>visibility<br> <li> Added comment explaining zoom controls are only visible in Drawing <br>Mode on desktop<br> <li> Ensures test validates the new conditional behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/QCX/pull/482/files#diff-c8b260470dd83e74a6321b1a8fde7a04d7d98e8029ee44cdb920cd96e4540dac">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Navigation controls now display exclusively on desktop devices.
  * Enhanced control cleanup when transitioning between drawing and map modes.
  * Improved map-type transition handling with better state management.

* **Tests**
  * Added test coverage for zoom control visibility in Drawing Mode on desktop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->