### PR TITLE
fix: FollowupPanel input submission bug

### DIFF
--- a/components/followup-panel.tsx
+++ b/components/followup-panel.tsx
@@ -8,6 +8,7 @@ import type { AI } from '@/app/actions'
 import { UserMessage } from './user-message'
 import { ArrowRight } from 'lucide-react'
 import { useMapData } from './map/map-data-context'
+import { nanoid } from '@/lib/utils'
 
 export function FollowupPanel() {
   const [input, setInput] = useState('')
@@ -17,10 +18,11 @@ export function FollowupPanel() {
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
-    const formData = new FormData(event.currentTarget as HTMLFormElement)
+    const formData = new FormData()
+    formData.append("input", input)
 
     const userMessage = {
-      id: Date.now(),
+      id: nanoid(),
       isGenerating: false,
       component: <UserMessage content={input} />
     }


### PR DESCRIPTION
Fixed a bug where the follow-up question input in the `FollowupPanel` component failed to submit correctly.

The issue was caused by using the native `FormData` constructor with the form element, which often fails to capture the current value of controlled React components.

**Changes:**
- Updated `handleSubmit` in `components/followup-panel.tsx` to explicitly create a `new FormData()` and append the `input` state value.
- Replaced `Date.now()` with `nanoid()` for message ID generation to maintain consistency with the rest of the codebase.
- Verified the fix with a successful `bun run build`.

---
*PR created automatically by Jules for task [14276778018306632149](https://jules.google.com/task/14276778018306632149) started by @ngoiyaeric*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal form data handling and message identification mechanisms in the follow-up panel component to enhance reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->