### PR TITLE
Fix system prompt defaults and user ID retrieval

### DIFF
--- a/app/actions.tsx
+++ b/app/actions.tsx
@@ -22,6 +22,7 @@ import { SearchSection } from '@/components/search-section'
 import SearchRelated from '@/components/search-related'
 import { GeoJsonLayer } from '@/components/map/geojson-layer'
 import { ResolutionCarousel } from '@/components/resolution-carousel'
+import { getCurrentUserIdOnServer } from '@/lib/auth/get-current-user'
 import { ResolutionImage } from '@/components/resolution-image'
 import { CopilotDisplay } from '@/components/copilot-display'
 import RetrieveSection from '@/components/retrieve-section'
@@ -397,7 +398,7 @@ async function submit(formData?: FormData, skip?: boolean) {
     } as CoreMessage)
   }
 
-  const userId = 'anonymous'
+  const userId = (await getCurrentUserIdOnServer()) || 'anonymous'
   const currentSystemPrompt = (await getSystemPrompt(userId)) || ''
   const mapProvider = formData?.get('mapProvider') as 'mapbox' | 'google'
 

--- a/components/settings/components/settings.tsx
+++ b/components/settings/components/settings.tsx
@@ -53,7 +53,7 @@ export type SettingsFormValues = z.infer<typeof settingsFormSchema>
 // Default values
 const defaultValues: Partial<SettingsFormValues> = {
   systemPrompt:
-    "You are a planetary copilot, an AI assistant designed to help users with information about planets, space exploration, and astronomy. Provide accurate, educational, and engaging responses about our solar system and beyond.",
+    "You are an AI assistant designed to help users with geospatial data, mapping, and environment-aware insights. Provide accurate and helpful responses based on the available tools and context.",
   selectedModel: "Grok 4.2",
   users: [],
 }


### PR DESCRIPTION
Updated the codebase to ensure that the system prompt is correctly retrieved for authenticated users and updated the hardcoded default values in the settings form.

Key changes:
1.  **Authenticated User ID Retrieval:** Modified `submit` in `app/actions.tsx` to use `getCurrentUserIdOnServer()` for fetching the user-specific system prompt from the database. It now correctly falls back to `'anonymous'` for unauthenticated sessions.
2.  **Default Prompt Update:** Changed the `defaultValues.systemPrompt` in `components/settings/components/settings.tsx` to a geospatial-focused prompt, replacing the previous "planetary copilot" (astronomy) default.
3.  **Code Consistency:** Added necessary imports and ensured that the logic for system prompt retrieval matches the user's current session state.

These changes ensure that user customizations to the system prompt are actually applied during chat interactions and that the "Reset to Defaults" button behaves as expected for the application's domain.

---
*PR created automatically by Jules for task [12021650852449529727](https://jules.google.com/task/12021650852449529727) started by @ngoiyaeric*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled server-side user authentication to automatically identify and personalize system context for authenticated users, replacing the default anonymous identification approach.
  * Reoriented assistant specialty from planetary copilot to geospatial and mapping specialist, with updated default behavior and system guidance aligned to these focus areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->