### PR TITLE
🛡️ Sentinel: Fix Mass Assignment in calendar notes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-22 - [Mass Assignment in Server Actions]
+**Vulnerability:** Use of object spreads (...data) in Drizzle .set() and .values() methods within Next.js Server Actions.
+**Learning:** Server Actions can receive any JSON payload from the client. Using spreads directly on these inputs can allow attackers to overwrite protected fields like 'userId' or 'id', leading to data corruption or privilege escalation.
+**Prevention:** Always explicitly map allowed fields from client-provided objects when performing database operations in Server Actions.

--- a/lib/actions/calendar.ts
+++ b/lib/actions/calendar.ts
@@ -73,7 +73,15 @@ export async function saveNote(noteData: NewCalendarNote | CalendarNote): Promis
         try {
             const [updatedNote] = await db
                 .update(calendarNotes)
-                .set({ ...noteData, updatedAt: new Date() })
+                .set({
+                    chatId: noteData.chatId,
+                    date: noteData.date,
+                    content: noteData.content,
+                    locationTags: noteData.locationTags,
+                    userTags: noteData.userTags,
+                    mapFeatureId: noteData.mapFeatureId,
+                    updatedAt: new Date()
+                })
                 .where(and(eq(calendarNotes.id, noteData.id), eq(calendarNotes.userId, userId)))
                 .returning();
             return updatedNote;
@@ -86,7 +94,15 @@ export async function saveNote(noteData: NewCalendarNote | CalendarNote): Promis
         try {
             const [newNote] = await db
                 .insert(calendarNotes)
-                .values({ ...noteData, userId })
+                .values({
+                    userId: userId,
+                    chatId: noteData.chatId,
+                    date: noteData.date,
+                    content: noteData.content,
+                    locationTags: noteData.locationTags,
+                    userTags: noteData.userTags,
+                    mapFeatureId: noteData.mapFeatureId,
+                })
                 .returning();
 
             if (newNote && newNote.chatId) {


### PR DESCRIPTION
This PR fixes a Mass Assignment (Overposting) vulnerability in the `saveNote` server action within `lib/actions/calendar.ts`. By explicitly listing the fields allowed for update and insert, we prevent potential data corruption or privilege escalation where a user could change the owner of a note or overwrite other protected fields.

---
*PR created automatically by Jules for task [12587019390571781091](https://jules.google.com/task/12587019390571781091) started by @ngoiyaeric*