### PR TITLE
🛡️ Sentinel: Fix IDOR and SQL Wildcard Enumeration vulnerabilities

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-16 - IDOR and Wildcard Enumeration in Server Actions
+**Vulnerability:** IDOR in `getChatMessages` and `updateDrawingContext` allowed unauthorized access/modification to chat data. `searchUsers` was susceptible to wildcard enumeration.
+**Learning:** Exported server actions in Next.js ('use server') are public endpoints and must implement their own authentication and authorization checks, even if they are only intended for use in protected pages.
+**Prevention:** Always retrieve the current user session within the server action and verify ownership/permissions before performing database operations. Escape special SQL characters in `LIKE`/`ILIKE` patterns from user input.

--- a/lib/actions/chat.ts
+++ b/lib/actions/chat.ts
@@ -57,7 +57,20 @@ export async function getChatMessages(chatId: string): Promise<DrizzleMessage[]>
     console.warn('getChatMessages called without chatId');
     return [];
   }
+
+  const userId = await getCurrentUserIdOnServer();
+  if (!userId) {
+    throw new Error('Unauthorized: Authentication required');
+  }
+
   try {
+    // Check if the user has access to this chat
+    const chat = await getChat(chatId, userId);
+    if (!chat) {
+      console.warn(`Unauthorized access attempt to chat ${chatId} by user ${userId}`);
+      return [];
+    }
+
     return dbGetMessagesByChatId(chatId);
   } catch (error) {
     console.error(`Error fetching messages for chat ${chatId} in getChatMessages:`, error);
@@ -127,15 +140,22 @@ export async function updateDrawingContext(chatId: string, contextData: { drawnF
     return { error: 'User not authenticated' };
   }
 
-  const newDrawingMessage: DbNewMessage = {
-    userId: userId,
-    chatId: chatId,
-    role: 'data',
-    content: JSON.stringify(contextData),
-    createdAt: new Date(),
-  };
-
   try {
+    // Check if the user has access to this chat and owns it
+    const chat = await getChat(chatId, userId);
+    if (!chat || chat.userId !== userId) {
+      console.warn(`Unauthorized drawing context update attempt for chat ${chatId} by user ${userId}`);
+      return { error: 'Unauthorized: Ownership required to update drawing context' };
+    }
+
+    const newDrawingMessage: DbNewMessage = {
+      userId: userId,
+      chatId: chatId,
+      role: 'data',
+      content: JSON.stringify(contextData),
+      createdAt: new Date(),
+    };
+
     const savedMessage = await dbCreateMessage(newDrawingMessage);
     if (!savedMessage) {
       throw new Error('Failed to save drawing context message.');

--- a/lib/actions/users.ts
+++ b/lib/actions/users.ts
@@ -189,18 +189,26 @@ export async function searchUsers(query: string) {
   noStore();
   if (!query) return [];
 
+  // Prevent DoS and long pattern matching
+  if (query.length > 255) {
+    throw new Error('Search query too long');
+  }
+
   const userId = await getCurrentUserIdOnServer();
   if (!userId) {
     throw new Error('Unauthorized');
   }
 
   try {
+    // Escape special PostgreSQL characters to prevent wildcard enumeration
+    const escapedQuery = query.replace(/[%_\\]/g, '\\$&');
+
     const result = await db.select({
       id: users.id,
       email: users.email,
     })
     .from(users)
-    .where(ilike(users.email, `%${query}%`))
+    .where(ilike(users.email, `%${escapedQuery}%`))
     .limit(10);
 
     return result;


### PR DESCRIPTION
This PR addresses several security vulnerabilities in the application's server actions:

1. **Insecure Direct Object Reference (IDOR) in `getChatMessages`**: Previously, any authenticated user could retrieve all messages for any `chatId` by calling the server action directly. I added a check that verifies the user has access to the chat (either as owner or if it's public) before returning messages.
2. **IDOR in `updateDrawingContext`**: Authenticated users could add data messages to any chat. I added an ownership check to restrict this to the chat owner.
3. **SQL Wildcard Enumeration in `searchUsers`**: The `ilike` search was susceptible to wildcard attacks (using `%` or `_`) which could allow a user to enumerate all user emails. I implemented escaping for these characters and added a 255-character length limit to the query.

Verified with static checks (lint/tsc) and manual code review. e2e tests were not runnable in the environment but the logic is defensive and safe.

---
*PR created automatically by Jules for task [13716273341324520366](https://jules.google.com/task/13716273341324520366) started by @ngoiyaeric*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security best practices documentation covering authentication and injection prevention.

* **Bug Fixes**
  * Improved authentication and authorization enforcement for messaging and context features.
  * Added input validation and protection against injection attacks in search functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->