### PR TITLE
🎨 Palette: Standardize tooltips and accessibility for icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-23 - [Standardizing Icon Button Accessibility and Tooltips]
+**Learning:** Icon-only buttons without labels or tooltips create "mystery meat navigation" and are inaccessible to screen readers. Standardizing on `Tooltip` for visual labels and `aria-label` for parity ensures a consistent and accessible UX across desktop and mobile.
+**Action:** Always wrap new icon-only buttons in `Tooltip` (desktop) and ensure `aria-label` is present for all icon-only interactions.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,6 +19,7 @@ import { HistorySidebar } from '@/components/history-sidebar'
 import { MapLoadingProvider } from '@/components/map-loading-context';
 import ConditionalLottie from '@/components/conditional-lottie';
 import { MapProvider as MapContextProvider } from '@/components/map/map-context'
+import { TooltipProvider } from '@/components/ui/tooltip'
 
 const fontSans = FontSans({
   subsets: ['latin'],
@@ -109,12 +110,14 @@ export default function RootLayout({
                   >
                     <MapContextProvider>
                       <MapLoadingProvider>
-                        <Header />
-                        <ConditionalLottie />
-                        {children}
-                        <HistorySidebar />
-                        <Footer />
-                        <Toaster />
+                        <TooltipProvider>
+                          <Header />
+                          <ConditionalLottie />
+                          {children}
+                          <HistorySidebar />
+                          <Footer />
+                          <Toaster />
+                        </TooltipProvider>
                       </MapLoadingProvider>
                     </MapContextProvider>
                   </ThemeProvider>

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -14,6 +14,7 @@ import { PartialRelated } from '@/lib/schema/related'
 import { getSuggestions } from '@/lib/actions/suggest'
 import { useMapData } from './map/map-data-context'
 import SuggestionsDropdown from './suggestions-dropdown'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 
 interface ChatPanelProps {
   messages: UIState
@@ -169,17 +170,22 @@ export const ChatPanel = forwardRef<ChatPanelRef, ChatPanelProps>(({ messages, i
           'fixed bottom-4 left-4 flex justify-start items-center pointer-events-none z-50'
         )}
       >
-        <Button
-          type="button"
-          variant={'ghost'}
-          size={'icon'}
-          className="rounded-full transition-all hover:scale-110 pointer-events-auto text-primary"
-          onClick={() => handleClear()}
-          data-testid="new-chat-button"
-          title="New Chat"
-        >
-          <Sprout size={28} className="fill-primary/20" />
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant={'ghost'}
+              size={'icon'}
+              className="rounded-full transition-all hover:scale-110 pointer-events-auto text-primary"
+              onClick={() => handleClear()}
+              data-testid="new-chat-button"
+              aria-label="New Chat"
+            >
+              <Sprout size={28} className="fill-primary/20" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>New Chat</TooltipContent>
+        </Tooltip>
       </div>
     )
   }
@@ -216,18 +222,24 @@ export const ChatPanel = forwardRef<ChatPanelRef, ChatPanelProps>(({ messages, i
             accept="text/plain,image/png,image/jpeg,image/webp"
           />
           {!isMobile && (
-            <Button
-              type="button"
-              variant={'ghost'}
-              size={'icon'}
-              className={cn(
-                'absolute top-1/2 transform -translate-y-1/2 left-3'
-              )}
-              onClick={handleAttachmentClick}
-              data-testid="desktop-attachment-button"
-            >
-              <Paperclip size={isMobile ? 18 : 20} />
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant={'ghost'}
+                  size={'icon'}
+                  className={cn(
+                    'absolute top-1/2 transform -translate-y-1/2 left-3'
+                  )}
+                  onClick={handleAttachmentClick}
+                  data-testid="desktop-attachment-button"
+                  aria-label="Attach File"
+                >
+                  <Paperclip size={isMobile ? 18 : 20} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Attach File</TooltipContent>
+            </Tooltip>
           )}
           <Textarea
             ref={inputRef}
@@ -295,9 +307,14 @@ export const ChatPanel = forwardRef<ChatPanelRef, ChatPanelProps>(({ messages, i
             <span className="text-sm text-muted-foreground truncate max-w-xs">
               {selectedFile.name}
             </span>
-            <Button variant="ghost" size="icon" onClick={clearAttachment} data-testid="clear-attachment-button">
-              <X size={16} />
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="ghost" size="icon" onClick={clearAttachment} data-testid="clear-attachment-button" aria-label="Clear attachment">
+                  <X size={16} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Clear attachment</TooltipContent>
+            </Tooltip>
           </div>
         </div>
       )}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -20,6 +20,7 @@ import { useUsageToggle } from './usage-toggle-context'
 import { useProfileToggle } from './profile-toggle-context'
 import { useHistoryToggle } from './history-toggle-context'
 import { useState, useEffect } from 'react'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 
 export const Header = () => {
   const { toggleCalendar } = useCalendarToggle()
@@ -52,15 +53,20 @@ export const Header = () => {
       </div>
       
       <div className="absolute left-1 flex items-center">
-        <Button variant="ghost" size="icon" onClick={toggleHistory} data-testid="logo-history-toggle">
-          <Image
-            src="/images/logo.svg"
-            alt="Logo"
-            width={20}
-            height={20}
-            className="h-5 w-auto"
-          />
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button variant="ghost" size="icon" onClick={toggleHistory} data-testid="logo-history-toggle" aria-label="Toggle history">
+              <Image
+                src="/images/logo.svg"
+                alt="Logo"
+                width={20}
+                height={20}
+                className="h-5 w-auto"
+              />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>History</TooltipContent>
+        </Tooltip>
         <h1 className="text-2xl font-poppins font-semibold text-primary">
           QCX
         </h1>
@@ -71,15 +77,25 @@ export const Header = () => {
         
         <MapToggle />
         
-        <Button variant="ghost" size="icon" onClick={toggleCalendar} title="Open Calendar" data-testid="calendar-toggle">
-          <CalendarDays className="h-[1.2rem] w-[1.2rem]" />
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button variant="ghost" size="icon" onClick={toggleCalendar} data-testid="calendar-toggle" aria-label="Open Calendar">
+              <CalendarDays className="h-[1.2rem] w-[1.2rem]" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Calendar</TooltipContent>
+        </Tooltip>
         
         <div id="header-search-portal" className="contents" />
         
-        <Button variant="ghost" size="icon" onClick={handleUsageToggle}>
-          <TentTree className="h-[1.2rem] w-[1.2rem]" />
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button variant="ghost" size="icon" onClick={handleUsageToggle} aria-label="Usage">
+              <TentTree className="h-[1.2rem] w-[1.2rem]" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Usage</TooltipContent>
+        </Tooltip>
         
         <ModeToggle />
         
@@ -89,7 +105,7 @@ export const Header = () => {
       {/* Mobile menu buttons */}
       <div className="flex md:hidden gap-2">
         
-        <Button variant="ghost" size="icon" onClick={handleUsageToggle}>
+        <Button variant="ghost" size="icon" onClick={handleUsageToggle} aria-label="Usage">
           <TentTree className="h-[1.2rem] w-[1.2rem]" />
         </Button>
         <ProfileToggle/>

--- a/components/mobile-icons-bar.tsx
+++ b/components/mobile-icons-bar.tsx
@@ -37,26 +37,26 @@ export const MobileIconsBar: React.FC<MobileIconsBarProps> = ({ onAttachmentClic
 
   return (
     <div className="mobile-icons-bar-content">
-      <Button variant="ghost" size="icon" onClick={handleNewChat} data-testid="mobile-new-chat-button">
+      <Button variant="ghost" size="icon" onClick={handleNewChat} data-testid="mobile-new-chat-button" aria-label="New Chat">
         <Plus className="h-[1.2rem] w-[1.2rem]" />
       </Button>
       <ProfileToggle />
       <MapToggle />
-      <Button variant="ghost" size="icon" onClick={toggleCalendar} title="Open Calendar" data-testid="mobile-calendar-button">
+      <Button variant="ghost" size="icon" onClick={toggleCalendar} aria-label="Open Calendar" data-testid="mobile-calendar-button">
         <CalendarDays className="h-[1.2rem] w-[1.2rem] transition-all rotate-0 scale-100" />
       </Button>
-      <Button variant="ghost" size="icon" data-testid="mobile-search-button">
+      <Button variant="ghost" size="icon" data-testid="mobile-search-button" aria-label="Search">
         <Search className="h-[1.2rem] w-[1.2rem] transition-all rotate-0 scale-100" />
       </Button>
       <a href="https://buy.stripe.com/14A3cv7K72TR3go14Nasg02" target="_blank" rel="noopener noreferrer">
-        <Button variant="ghost" size="icon">
+        <Button variant="ghost" size="icon" aria-label="Purchase Credits">
           <TentTree className="h-[1.2rem] w-[1.2rem] transition-all rotate-0 scale-100" />
         </Button>
       </a>
-      <Button variant="ghost" size="icon" onClick={onAttachmentClick} data-testid="mobile-attachment-button">
+      <Button variant="ghost" size="icon" onClick={onAttachmentClick} data-testid="mobile-attachment-button" aria-label="Attach File">
         <Paperclip className="h-[1.2rem] w-[1.2rem] transition-all rotate-0 scale-100" />
       </Button>
-      <Button variant="ghost" size="icon" data-testid="mobile-submit-button" onClick={onSubmitClick}>
+      <Button variant="ghost" size="icon" data-testid="mobile-submit-button" onClick={onSubmitClick} aria-label="Send Message">
         <ArrowRight className="h-[1.2rem] w-[1.2rem] transition-all rotate-0 scale-100" />
       </Button>
       <History location="header" />


### PR DESCRIPTION
Improved accessibility and UX by standardizing tooltips and ARIA labels for icon-only buttons.

---
*PR created automatically by Jules for task [7713885870246008838](https://jules.google.com/task/7713885870246008838) started by @ngoiyaeric*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added tooltips to icon buttons across the app, providing helpful labels for icon-only controls.
  * Enhanced screen reader accessibility with proper labeling on interactive icon buttons for improved mobile and desktop usability.

* **Documentation**
  * Added accessibility standards documentation for icon-only button implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->