### PR TITLE
🛡️ Sentinel: Fix mass assignment and wildcard enumeration vulnerabilities

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,11 @@
+# Sentinel Security Journal
+
+## 2025-05-14 - [Vulnerability] Mass Assignment in Drizzle Server Actions
+**Vulnerability:** Use of the spread operator (`...noteData`) in Drizzle `.set()` or `.values()` calls allowed client-supplied input to overwrite protected fields like `userId`.
+**Learning:** Even if the `where` clause checks for the correct `userId`, mass assignment can still allow a user to "transfer" their records to another user by changing the `userId` in the payload.
+**Prevention:** Always explicitly list mutable columns in database operations within server actions.
+
+## 2025-05-14 - [Vulnerability] Wildcard Enumeration in ILIKE Queries
+**Vulnerability:** Unsanitized user input in `ILIKE` patterns (`%${query}%`) allowed authenticated users to enumerate records (e.g., all user emails) by using `%` or `_` wildcards.
+**Learning:** Drizzle's `ilike` operator does not automatically escape wildcards. Postgres requires an explicit `ESCAPE` clause to treat these characters as literals.
+**Prevention:** Sanitize user input by escaping `%`, `_`, and `\` and using `sql`${column} ILIKE ${pattern} ESCAPE '\\'` template literals.

--- a/lib/actions/calendar.ts
+++ b/lib/actions/calendar.ts
@@ -73,7 +73,15 @@ export async function saveNote(noteData: NewCalendarNote | CalendarNote): Promis
         try {
             const [updatedNote] = await db
                 .update(calendarNotes)
-                .set({ ...noteData, updatedAt: new Date() })
+                .set({
+                    content: noteData.content,
+                    date: noteData.date,
+                    chatId: noteData.chatId,
+                    locationTags: noteData.locationTags,
+                    userTags: noteData.userTags,
+                    mapFeatureId: noteData.mapFeatureId,
+                    updatedAt: new Date()
+                })
                 .where(and(eq(calendarNotes.id, noteData.id), eq(calendarNotes.userId, userId)))
                 .returning();
             return updatedNote;
@@ -86,7 +94,15 @@ export async function saveNote(noteData: NewCalendarNote | CalendarNote): Promis
         try {
             const [newNote] = await db
                 .insert(calendarNotes)
-                .values({ ...noteData, userId })
+                .values({
+                    userId,
+                    content: noteData.content,
+                    date: noteData.date,
+                    chatId: noteData.chatId,
+                    locationTags: noteData.locationTags,
+                    userTags: noteData.userTags,
+                    mapFeatureId: noteData.mapFeatureId,
+                })
                 .returning();
 
             if (newNote && newNote.chatId) {

--- a/lib/actions/users.ts
+++ b/lib/actions/users.ts
@@ -3,7 +3,7 @@
 import { revalidatePath, unstable_noStore as noStore } from 'next/cache';
 import { db } from '@/lib/db';
 import { users } from '@/lib/db/schema';
-import { eq, ilike } from 'drizzle-orm';
+import { eq, ilike, sql } from 'drizzle-orm';
 import { getCurrentUserIdOnServer } from '@/lib/auth/get-current-user';
 
 export type UserRole = "admin" | "editor" | "viewer";
@@ -187,7 +187,8 @@ export async function saveSelectedModel(model: string): Promise<{ success: boole
  */
 export async function searchUsers(query: string) {
   noStore();
-  if (!query) return [];
+  // Enforce length limit and handle empty query to prevent DoS/enumeration
+  if (!query || query.length > 100) return [];
 
   const userId = await getCurrentUserIdOnServer();
   if (!userId) {
@@ -195,12 +196,15 @@ export async function searchUsers(query: string) {
   }
 
   try {
+    // Escape special ILIKE characters (%, _, \) to prevent wildcard enumeration
+    const escapedQuery = query.replace(/[%_\\]/g, '\\$&');
+
     const result = await db.select({
       id: users.id,
       email: users.email,
     })
     .from(users)
-    .where(ilike(users.email, `%${query}%`))
+    .where(sql`${users.email} ILIKE ${'%' + escapedQuery + '%'} ESCAPE '\\'`)
     .limit(10);
 
     return result;


### PR DESCRIPTION
This PR addresses two security vulnerabilities identified in the server actions:

1. **Mass Assignment Prevention**: In `lib/actions/calendar.ts`, the `saveNote` action used the spread operator on client-supplied data when updating or inserting into the database. This could allow a malicious user to overwrite protected fields like `userId`. I refactored the code to explicitly pick only the allowed mutable columns.

2. **Wildcard Enumeration Hardening**: In `lib/actions/users.ts`, the `searchUsers` action allowed unsanitized input in an `ILIKE` query. This enabled users to enumerate all email addresses by searching for `%`. I added a 100-character length limit, implemented escaping for special SQL characters (`%`, `_`, `\`), and used an explicit `ESCAPE` clause in the query.

Verified with `bun run lint`, `bun run build`, and manual code inspection.

---
*PR created automatically by Jules for task [8454964759189557742](https://jules.google.com/task/8454964759189557742) started by @ngoiyaeric*