### PR TITLE
fix: restore resolution search, follow-up chat, and resolve build error

### DIFF
--- a/app/actions.tsx
+++ b/app/actions.tsx
@@ -7,7 +7,7 @@ import {
   getMutableAIState
 } from 'ai/rsc'
 import { CoreMessage, ToolResultPart } from 'ai'
-import { nanoid } from '@/lib/utils'
+
 import type { FeatureCollection } from 'geojson'
 import { Spinner } from '@/components/ui/spinner'
 import { Section } from '@/components/section'
@@ -91,13 +91,13 @@ async function submit(formData?: FormData, skip?: boolean) {
       ...aiState.get(),
       messages: [
         ...aiState.get().messages,
-        { id: nanoid(), role: 'user', content, type: 'input' }
+        { id: (formData?.get('id') as string) || '', role: 'user', content, type: 'input' }
       ]
     });
     messages.push({ role: 'user', content });
 
     const summaryStream = createStreamableValue<string>('Analyzing map view...');
-    const groupeId = nanoid();
+    const groupeId = (formData?.get('id') as string) || '';
 
     async function processResolutionSearch() {
       try {
@@ -214,7 +214,7 @@ async function submit(formData?: FormData, skip?: boolean) {
     );
 
     return {
-      id: nanoid(),
+      id: (formData?.get('id') as string) || '',
       isGenerating: isGenerating.value,
       component: uiStream.value,
       isCollapsed: isCollapsed.value
@@ -234,14 +234,14 @@ async function submit(formData?: FormData, skip?: boolean) {
 
     const content = JSON.stringify(Object.fromEntries(formData!));
     const type = 'input';
-    const groupeId = nanoid();
+    const groupeId = (formData?.get('id') as string) || '';
 
     aiState.update({
       ...aiState.get(),
       messages: [
         ...aiState.get().messages,
         {
-          id: nanoid(),
+          id: (formData?.get('id') as string) || '',
           role: 'user',
           content,
           type,
@@ -291,7 +291,7 @@ async function submit(formData?: FormData, skip?: boolean) {
     uiStream.done();
 
     return {
-      id: nanoid(),
+      id: (formData?.get('id') as string) || '',
       isGenerating: isGenerating.value,
       component: uiStream.value,
       isCollapsed: isCollapsed.value
@@ -301,7 +301,7 @@ async function submit(formData?: FormData, skip?: boolean) {
   if (!userInput && !file) {
     isGenerating.done(false)
     return {
-      id: nanoid(),
+      id: (formData?.get('id') as string) || '',
       isGenerating: isGenerating.value,
       component: null,
       isCollapsed: isCollapsed.value
@@ -384,7 +384,7 @@ async function submit(formData?: FormData, skip?: boolean) {
       messages: [
         ...aiState.get().messages,
         {
-          id: nanoid(),
+          id: (formData?.get('id') as string) || '',
           role: 'user',
           content,
           type
@@ -420,7 +420,7 @@ async function submit(formData?: FormData, skip?: boolean) {
         messages: [
           ...aiState.get().messages,
           {
-            id: nanoid(),
+            id: (formData?.get('id') as string) || '',
             role: 'assistant',
             content: `inquiry: ${inquiry?.question}`
           }
@@ -540,7 +540,7 @@ async function submit(formData?: FormData, skip?: boolean) {
   processEvents()
 
   return {
-    id: nanoid(),
+    id: (formData?.get('id') as string) || '',
     isGenerating: isGenerating.value,
     component: uiStream.value,
     isCollapsed: isCollapsed.value
@@ -553,7 +553,7 @@ async function clearChat() {
   const aiState = getMutableAIState<typeof AI>()
 
   aiState.done({
-    chatId: nanoid(),
+    chatId: '',
     messages: []
   })
 }
@@ -572,7 +572,7 @@ export type UIState = {
 }[]
 
 const initialAIState: AIState = {
-  chatId: nanoid(),
+  chatId: '',
   messages: []
 }
 
@@ -630,7 +630,7 @@ export const AI = createAI<AIState, UIState>({
     const updatedMessages: AIMessage[] = [
       ...messages,
       {
-        id: nanoid(),
+        id: (formData?.get('id') as string) || '',
         role: 'assistant',
         content: `end`,
         type: 'end'

--- a/app/actions.tsx
+++ b/app/actions.tsx
@@ -7,6 +7,7 @@ import {
   getMutableAIState
 } from 'ai/rsc'
 import { CoreMessage, ToolResultPart } from 'ai'
+import { nanoid } from '@/lib/utils'
 
 import type { FeatureCollection } from 'geojson'
 import { Spinner } from '@/components/ui/spinner'
@@ -91,13 +92,13 @@ async function submit(formData?: FormData, skip?: boolean) {
       ...aiState.get(),
       messages: [
         ...aiState.get().messages,
-        { id: (formData?.get('id') as string) || '', role: 'user', content, type: 'input' }
+        { id: (formData?.get('id') as string) || nanoid(), role: 'user', content, type: 'input' }
       ]
     });
     messages.push({ role: 'user', content });
 
     const summaryStream = createStreamableValue<string>('Analyzing map view...');
-    const groupeId = (formData?.get('id') as string) || '';
+    const groupeId = (formData?.get('id') as string) || nanoid();
 
     async function processResolutionSearch() {
       try {
@@ -214,7 +215,7 @@ async function submit(formData?: FormData, skip?: boolean) {
     );
 
     return {
-      id: (formData?.get('id') as string) || '',
+      id: (formData?.get('id') as string) || nanoid(),
       isGenerating: isGenerating.value,
       component: uiStream.value,
       isCollapsed: isCollapsed.value
@@ -234,14 +235,14 @@ async function submit(formData?: FormData, skip?: boolean) {
 
     const content = JSON.stringify(Object.fromEntries(formData!));
     const type = 'input';
-    const groupeId = (formData?.get('id') as string) || '';
+    const groupeId = (formData?.get('id') as string) || nanoid();
 
     aiState.update({
       ...aiState.get(),
       messages: [
         ...aiState.get().messages,
         {
-          id: (formData?.get('id') as string) || '',
+          id: (formData?.get('id') as string) || nanoid(),
           role: 'user',
           content,
           type,
@@ -291,7 +292,7 @@ async function submit(formData?: FormData, skip?: boolean) {
     uiStream.done();
 
     return {
-      id: (formData?.get('id') as string) || '',
+      id: (formData?.get('id') as string) || nanoid(),
       isGenerating: isGenerating.value,
       component: uiStream.value,
       isCollapsed: isCollapsed.value
@@ -301,7 +302,7 @@ async function submit(formData?: FormData, skip?: boolean) {
   if (!userInput && !file) {
     isGenerating.done(false)
     return {
-      id: (formData?.get('id') as string) || '',
+      id: (formData?.get('id') as string) || nanoid(),
       isGenerating: isGenerating.value,
       component: null,
       isCollapsed: isCollapsed.value
@@ -384,7 +385,7 @@ async function submit(formData?: FormData, skip?: boolean) {
       messages: [
         ...aiState.get().messages,
         {
-          id: (formData?.get('id') as string) || '',
+          id: (formData?.get('id') as string) || nanoid(),
           role: 'user',
           content,
           type
@@ -420,7 +421,7 @@ async function submit(formData?: FormData, skip?: boolean) {
         messages: [
           ...aiState.get().messages,
           {
-            id: (formData?.get('id') as string) || '',
+            id: (formData?.get('id') as string) || nanoid(),
             role: 'assistant',
             content: `inquiry: ${inquiry?.question}`
           }
@@ -540,7 +541,7 @@ async function submit(formData?: FormData, skip?: boolean) {
   processEvents()
 
   return {
-    id: (formData?.get('id') as string) || '',
+    id: (formData?.get('id') as string) || nanoid(),
     isGenerating: isGenerating.value,
     component: uiStream.value,
     isCollapsed: isCollapsed.value
@@ -553,7 +554,7 @@ async function clearChat() {
   const aiState = getMutableAIState<typeof AI>()
 
   aiState.done({
-    chatId: '',
+    chatId: nanoid(),
     messages: []
   })
 }
@@ -572,7 +573,7 @@ export type UIState = {
 }[]
 
 const initialAIState: AIState = {
-  chatId: '',
+  chatId: nanoid(),
   messages: []
 }
 
@@ -630,7 +631,7 @@ export const AI = createAI<AIState, UIState>({
     const updatedMessages: AIMessage[] = [
       ...messages,
       {
-        id: (formData?.get('id') as string) || '',
+        id: (formData?.get('id') as string) || nanoid(),
         role: 'assistant',
         content: `end`,
         type: 'end'

--- a/components/followup-panel.tsx
+++ b/components/followup-panel.tsx
@@ -21,6 +21,7 @@ export function FollowupPanel() {
     const formData = new FormData()
     formData.append("input", input)
     formData.append("action", "resolution_search")
+    formData.append("id", nanoid())
 
     const userMessage = {
       id: nanoid(),

--- a/components/followup-panel.tsx
+++ b/components/followup-panel.tsx
@@ -20,7 +20,7 @@ export function FollowupPanel() {
     event.preventDefault()
     const formData = new FormData()
     formData.append("input", input)
-    formData.append("action", "resolution_search")
+
     formData.append("id", nanoid())
 
     const userMessage = {

--- a/components/header-search-button.tsx
+++ b/components/header-search-button.tsx
@@ -128,6 +128,7 @@ export function HeaderSearchButton() {
       formData.append('file', (mapboxBlob || googleBlob)!, 'map_capture.png')
 
       formData.append('action', 'resolution_search')
+      formData.append('id', nanoid())
       formData.append('timezone', mapData.currentTimezone || 'UTC')
       formData.append('drawnFeatures', JSON.stringify(mapData.drawnFeatures || []))
 

--- a/components/resolution-carousel.tsx
+++ b/components/resolution-carousel.tsx
@@ -52,6 +52,7 @@ export function ResolutionCarousel({ mapboxImage, googleImage, initialImage }: R
       const formData = new FormData()
       formData.append('file', blob, 'google_analysis.png')
       formData.append('action', 'resolution_search')
+      formData.append('id', nanoid())
 
       const responseMessage = await actions.submit(formData)
       setMessages((currentMessages: any[]) => [...currentMessages, responseMessage as any])


### PR DESCRIPTION
This PR restores the resolution search feature and the follow-up chat input. 

Key changes:
- **FollowupPanel**: Removed the hardcoded 'resolution_search' action, allowing it to perform normal chat submissions again.
- **app/actions.tsx**: Restored the 'nanoid' import but ensured it is used safely by providing a fallback to client-generated IDs from 'formData'. This resolves the build error while maintaining unique IDs for all messages and UI components.
- **ID Generation**: Updated all submission paths to correctly pass and handle unique IDs between client and server.