### PR TITLE
Add image preview to ChatPanel

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -33,6 +33,7 @@ export const ChatPanel = forwardRef<ChatPanelRef, ChatPanelProps>(({ messages, i
   const { mapProvider } = useSettingsStore()
   const [isMobile, setIsMobile] = useState(false)
   const [selectedFile, setSelectedFile] = useState<File | null>(null)
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null)
   const [suggestions, setSuggestionsState] = useState<PartialRelated | null>(null)
   const setSuggestions = useCallback((s: PartialRelated | null) => {
     setSuggestionsState(s)
@@ -156,6 +157,16 @@ export const ChatPanel = forwardRef<ChatPanelRef, ChatPanelProps>(({ messages, i
     },
     [mapData, setSuggestions]
   )
+  useEffect(() => {
+    if (selectedFile && selectedFile.type.startsWith("image/")) {
+      const url = URL.createObjectURL(selectedFile)
+      setPreviewUrl(url)
+      return () => URL.revokeObjectURL(url)
+    } else {
+      setPreviewUrl(null)
+    }
+  }, [selectedFile])
+
 
   useEffect(() => {
     inputRef.current?.focus()
@@ -290,9 +301,20 @@ export const ChatPanel = forwardRef<ChatPanelRef, ChatPanelProps>(({ messages, i
         </div>
       </form>
       {selectedFile && (
-        <div className="w-full px-4 pb-2 mb-2">
-          <div className="flex items-center justify-between p-2 bg-muted rounded-lg">
-            <span className="text-sm text-muted-foreground truncate max-w-xs">
+        <div className="w-full px-4 pb-2 mb-2" data-testid="attached-image">
+          <div className="relative flex items-center justify-between p-2 bg-muted rounded-lg group">
+            {previewUrl ? (
+              <div className="relative mr-2">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={previewUrl}
+                  alt="Preview"
+                  className="h-16 w-16 object-cover rounded-md border border-border"
+                  data-testid="image-preview"
+                />
+              </div>
+            ) : null}
+            <span className="text-sm text-muted-foreground truncate max-w-xs flex-1">
               {selectedFile.name}
             </span>
             <Button variant="ghost" size="icon" onClick={clearAttachment} data-testid="clear-attachment-button">


### PR DESCRIPTION
Added image preview logic using URL.createObjectURL and updated UI to show thumbnails for attached images.

---
*PR created automatically by Jules for task [6818274094371257842](https://jules.google.com/task/6818274094371257842) started by @ngoiyaeric*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image previews now display when you attach images to your messages, allowing you to visually confirm your selection before sending. The attachment display area has been improved with a responsive layout that shows image previews alongside file names for better visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->