### PR TITLE
🔒 Sentinel: [High] Fix IDOR in getSystemPrompt and saveSystemPrompt

### DIFF
--- a/app/actions.tsx
+++ b/app/actions.tsx
@@ -397,8 +397,8 @@ async function submit(formData?: FormData, skip?: boolean) {
     } as CoreMessage)
   }
 
-  const userId = 'anonymous'
-  const currentSystemPrompt = (await getSystemPrompt(userId)) || ''
+
+  const currentSystemPrompt = (await getSystemPrompt()) || ''
   const mapProvider = formData?.get('mapProvider') as 'mapbox' | 'google'
 
   async function processEvents() {

--- a/components/settings/components/settings.tsx
+++ b/components/settings/components/settings.tsx
@@ -86,7 +86,7 @@ export function Settings({ initialTab = "system-prompt" }: SettingsProps) {
       if (!userId || authLoading) return;
 
       const [existingPrompt, selectedModel] = await Promise.all([
-        getSystemPrompt(userId),
+        getSystemPrompt(),
         getSelectedModel(),
       ]);
 
@@ -119,7 +119,7 @@ export function Settings({ initialTab = "system-prompt" }: SettingsProps) {
     try {
       // Save the system prompt and selected model
       const [promptSaveResult, modelSaveResult] = await Promise.all([
-        saveSystemPrompt(userId, data.systemPrompt),
+        saveSystemPrompt(data.systemPrompt),
         saveSelectedModel(data.selectedModel),
       ]);
 

--- a/lib/actions/chat.ts
+++ b/lib/actions/chat.ts
@@ -148,9 +148,9 @@ export async function updateDrawingContext(chatId: string, contextData: { drawnF
 }
 
 export async function saveSystemPrompt(
-  userId: string,
   prompt: string
 ): Promise<{ success?: boolean; error?: string }> {
+  const userId = await getCurrentUserIdOnServer()
   if (!userId) return { error: 'User ID is required' }
   if (!prompt) return { error: 'Prompt is required' }
 
@@ -166,9 +166,8 @@ export async function saveSystemPrompt(
   }
 }
 
-export async function getSystemPrompt(
-  userId: string
-): Promise<string | null> {
+export async function getSystemPrompt(): Promise<string | null> {
+  const userId = await getCurrentUserIdOnServer()
   if (!userId) return null
 
   try {


### PR DESCRIPTION
🎯 **What:** The `getSystemPrompt` and `saveSystemPrompt` actions in `lib/actions/chat.ts` accepted a `userId` parameter and used it directly in database queries without verifying if the caller was authorized to access or modify that user's data. This allowed any authenticated user (or potentially unauthenticated users if `userId` was guessed/enumerated, though UUIDs make this harder) to read or write other users' system prompts.

⚠️ **Risk:** An attacker could retrieve another user's custom system prompt (potentially sensitive intellectual property or personal instructions) or overwrite it with a malicious prompt (e.g., prompt injection, defacement).

🛡️ **Solution:**
- Refactored `getSystemPrompt` and `saveSystemPrompt` to remove the `userId` parameter.
- The functions now internally retrieve the authenticated user's ID using `getCurrentUserIdOnServer()`.
- If no user is authenticated, the functions return `null` or an error, ensuring only the owner can access their data.
- Updated `components/settings/components/settings.tsx` and `app/actions.tsx` to call these functions without arguments.
- Verified changes with `tsc` to ensure type safety.

---
*PR created automatically by Jules for task [1638498258475748766](https://jules.google.com/task/1638498258475748766) started by @ngoiyaeric*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal system prompt handling by removing explicit user identifier parameters. The system now automatically retrieves user context server-side, streamlining the underlying architecture while maintaining the same functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->