### PR TITLE
🧹 Refactor getChat to unify query logic

### DIFF
--- a/lib/actions/chat-db.ts
+++ b/lib/actions/chat-db.ts
@@ -20,22 +20,21 @@ export type NewMessage = typeof messages.$inferInsert;
  * @returns The chat object if found and accessible, otherwise null.
  */
 export async function getChat(id: string, userId: string): Promise<Chat | null> {
-  if (!userId) {
+  const conditions = [eq(chats.id, id)];
+
+  if (userId) {
+    conditions.push(sql`(${chats.userId} = ${userId} OR ${chats.visibility} = 'public')`);
+  } else {
     console.warn('getChat called without userId');
     // Potentially allow fetching public chats if userId is null for anonymous users
-    const result = await db.select().from(chats).where(and(eq(chats.id, id), eq(chats.visibility, 'public'))).limit(1);
-    return result[0] || null;
+    conditions.push(eq(chats.visibility, 'public'));
   }
 
   const result = await db.select()
     .from(chats)
-    .where(
-      and(
-        eq(chats.id, id),
-        sql`${chats.userId} = ${userId} OR ${chats.visibility} = 'public'`
-      )
-    )
+    .where(and(...conditions))
     .limit(1);
+
   return result[0] || null;
 }
 


### PR DESCRIPTION
This change refactors the `getChat` function in `lib/actions/chat-db.ts` to remove redundant query logic. The original implementation had two separate `db.select` calls depending on whether `userId` was present. The new implementation constructs the `where` conditions dynamically, pushing the `userId` check or the public visibility check as needed, and then executes a single query.

This simplifies the code, reduces potential for inconsistency, and maintains the original access control logic:
- If `userId` is missing, only public chats are fetched.
- If `userId` is present, chats owned by the user OR public chats are fetched.

Verified logic with a temporary unit test that mocked the database interactions using `bun:test`. Removed the temporary test file before submission.

---
*PR created automatically by Jules for task [3967313318739502162](https://jules.google.com/task/3967313318739502162) started by @ngoiyaeric*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced chat retrieval to properly handle user-authenticated and public chat access scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->