### PR TITLE
🧹 Fix unused errorMessage in app/api/chats/all/route.ts

### DIFF
--- a/app/api/chats/all/route.ts
+++ b/app/api/chats/all/route.ts
@@ -25,6 +25,7 @@ export async function DELETE() {
     console.error('Error clearing history via API:', error);
     let errorMessage = 'Internal Server Error clearing history';
     if (error instanceof Error && error.message) {
+      errorMessage = error.message;
         // Use the error message from dbClearHistory if available (e.g., "User ID is required")
         // This depends on dbClearHistory actually throwing or returning specific error messages.
         // The current dbClearHistory in chat.ts returns {error: ...} which won't be caught here as an Error instance directly.


### PR DESCRIPTION
- Fixed unused `errorMessage` variable in `app/api/chats/all/route.ts` to ensure specific error messages are returned to the client.
- Verified changes with `bun x tsc --noEmit`, `bun run lint`, and `bun run build`.

---
*PR created automatically by Jules for task [10593634855385494504](https://jules.google.com/task/10593634855385494504) started by @ngoiyaeric*