### PR TITLE
🔒 Fix IDOR vulnerability in getSystemPrompt and saveSystemPrompt

### DIFF
--- a/app/actions.tsx
+++ b/app/actions.tsx
@@ -397,8 +397,8 @@ async function submit(formData?: FormData, skip?: boolean) {
     } as CoreMessage)
   }
 
-  const userId = 'anonymous'
-  const currentSystemPrompt = (await getSystemPrompt(userId)) || ''
+
+  const currentSystemPrompt = (await getSystemPrompt()) || ''
   const mapProvider = formData?.get('mapProvider') as 'mapbox' | 'google'
 
   async function processEvents() {

--- a/components/settings/components/settings.tsx
+++ b/components/settings/components/settings.tsx
@@ -86,7 +86,7 @@ export function Settings({ initialTab = "system-prompt" }: SettingsProps) {
       if (!userId || authLoading) return;
 
       const [existingPrompt, selectedModel] = await Promise.all([
-        getSystemPrompt(userId),
+        getSystemPrompt(),
         getSelectedModel(),
       ]);
 
@@ -119,7 +119,7 @@ export function Settings({ initialTab = "system-prompt" }: SettingsProps) {
     try {
       // Save the system prompt and selected model
       const [promptSaveResult, modelSaveResult] = await Promise.all([
-        saveSystemPrompt(userId, data.systemPrompt),
+        saveSystemPrompt(data.systemPrompt),
         saveSelectedModel(data.selectedModel),
       ]);
 

--- a/lib/actions/chat.ts
+++ b/lib/actions/chat.ts
@@ -148,10 +148,10 @@ export async function updateDrawingContext(chatId: string, contextData: { drawnF
 }
 
 export async function saveSystemPrompt(
-  userId: string,
   prompt: string
 ): Promise<{ success?: boolean; error?: string }> {
-  if (!userId) return { error: 'User ID is required' }
+  const userId = await getCurrentUserIdOnServer()
+  if (!userId) return { error: 'User not authenticated' }
   if (!prompt) return { error: 'Prompt is required' }
 
   try {
@@ -166,9 +166,8 @@ export async function saveSystemPrompt(
   }
 }
 
-export async function getSystemPrompt(
-  userId: string
-): Promise<string | null> {
+export async function getSystemPrompt(): Promise<string | null> {
+  const userId = await getCurrentUserIdOnServer()
   if (!userId) return null
 
   try {


### PR DESCRIPTION
The `getSystemPrompt` and `saveSystemPrompt` actions in `lib/actions/chat.ts` were vulnerable to IDOR (Insecure Direct Object Reference) because they accepted a `userId` parameter from the client without verifying if it matched the authenticated user's ID. An attacker could potentially retrieve or modify another user's system prompt by manipulating this parameter.

This PR fixes the vulnerability by:
1.  Removing the `userId` parameter from both functions.
2.  Using `getCurrentUserIdOnServer()` inside the functions to retrieve the authenticated user's ID securely.
3.  Ensuring that only authenticated users can access or modify their own system prompts.
4.  Updating the usage of these functions in `components/settings/components/settings.tsx` and `app/actions.tsx` to match the new signatures.
5.  Cleaning up the unused `userId` assignment in `app/actions.tsx`.

### Verification
- Ran `bun run build` to verify type safety and successful compilation.
- Attempted to run E2E tests (`bun run test:e2e`), but encountered timeouts likely due to unrelated popup issues in the test environment.
- Verified logic correctness: The vulnerability is patched by relying solely on the server-side session for user identification.

---
*PR created automatically by Jules for task [18185013760478449722](https://jules.google.com/task/18185013760478449722) started by @ngoiyaeric*