### PR TITLE
Add support for Grok 4.3 model selection

### DIFF
--- a/components/settings/components/model-selection-form.tsx
+++ b/components/settings/components/model-selection-form.tsx
@@ -35,12 +35,20 @@ const models = [
     badgeVariant: "default" as const,
   },
   {
-    id: "Grok 4.2",
-    name: "Grok 4.2",
-    description: "The latest from xAI, pushing the boundaries of reasoning and problem-solving.",
+    id: "Grok 4.3",
+    name: "Grok 4.3",
+    description: "The latest from xAI, featuring enhanced reasoning and real-time knowledge.",
     icon: Rocket,
     badge: "New",
     badgeVariant: "secondary" as const,
+  },
+  {
+    id: "Grok 4.2",
+    name: "Grok 4.2",
+    description: "Reliable reasoning model from xAI, pushing the boundaries of problem-solving.",
+    icon: Rocket,
+    badge: "Stable",
+    badgeVariant: "outline" as const,
   },
   {
     id: "Gemini 3.1 Pro",

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -34,6 +34,22 @@ export async function getModel(requireVision: boolean = false) {
 
   if (selectedModel) {
     switch (selectedModel) {
+      case 'Grok 4.3':
+        if (xaiApiKey) {
+          const xai = createXai({
+            apiKey: xaiApiKey,
+            baseURL: 'https://api.x.ai/v1',
+          });
+          try {
+            return xai('grok-latest');
+          } catch (error) {
+            console.error('Selected model "Grok 4.3" is configured but failed to initialize.', error);
+            throw new Error('Failed to initialize selected model.');
+          }
+        } else {
+            console.error('User selected "Grok 4.3" but XAI_API_KEY is not set.');
+            throw new Error('Selected model is not configured.');
+        }
       case 'Grok 4.2':
         if (xaiApiKey) {
           const xai = createXai({


### PR DESCRIPTION
This PR adds support for the newly released Grok 4.3 model from xAI. Both Grok 4.2 and Grok 4.3 are now available in the settings and can be toggled by the user.

Key changes:
- UI: Added "Grok 4.3" option to `ModelSelectionForm` with a "New" badge.
- Backend: Updated `getModel` in `lib/utils/index.ts` to map "Grok 4.3" selection to the `grok-latest` model ID.
- Logic: Preserved "Grok 4.2" support using `grok-4-fast-non-reasoning`.

Fixes: https://github.com/QueueLab/QCX/issues/581

---
*PR created automatically by Jules for task [17538991638682265224](https://jules.google.com/task/17538991638682265224) started by @ngoiyaeric*