### PR TITLE
fix: gate search tool registration on TAVILY_API_KEY presence

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -20,6 +20,10 @@ NEXT_PUBLIC_COMPOSIO_USER_ID=user@example.com
 # Gemini 3.1 Pro (Google Generative AI)
 GEMINI_3_PRO_API_KEY=your_gemini_3_pro_api_key_here
 
+# Search API (https://tavily.com)
+# If not set, the `search` tool is skipped and the LLM answers from its own knowledge.
+TAVILY_API_KEY=your_tavily_api_key
+
 # Supabase Credentials
 NEXT_PUBLIC_SUPABASE_URL=YOUR_SUPABASE_URL_HERE
 NEXT_PUBLIC_SUPABASE_ANON_KEY=YOUR_SUPABASE_ANON_KEY_HERE

--- a/lib/agents/tools/index.tsx
+++ b/lib/agents/tools/index.tsx
@@ -14,10 +14,6 @@ export interface ToolProps {
 
 export const getTools = ({ uiStream, fullResponse, mapProvider }: ToolProps) => {
   const tools: any = {
-    search: searchTool({
-      uiStream,
-      fullResponse
-    }),
     retrieve: retrieveTool({
       uiStream,
       fullResponse
@@ -25,6 +21,13 @@ export const getTools = ({ uiStream, fullResponse, mapProvider }: ToolProps) => 
     geospatialQueryTool: geospatialTool({
       uiStream,
       mapProvider
+    })
+  }
+
+  if (process.env.TAVILY_API_KEY) {
+    tools.search = searchTool({
+      uiStream,
+      fullResponse
     })
   }
 


### PR DESCRIPTION
This PR matches the existing `SERPER_API_KEY` gating pattern (`lib/agents/tools/index.tsx:31`) for `TAVILY_API_KEY`, so the search tool is only registered when its required key is present. Previously the LLM would attempt search even on deployments without Tavily configured, surfacing "An error occurred while searching for..." in the UI on any search-y query without providing any further explanation.

  ## Key Changes
  - [lib/agents/tools/index.tsx](https://github.com/QueueLab/QCX/blob/d0efce44315acd34c12d4cf08b70848859a18466/lib/agents/tools/index.tsx): register `search` only when `TAVILY_API_KEY` is set, matching the existing pattern used for `videoSearch` + `SERPER_API_KEY`.
  - [.env.local.example](https://github.com/QueueLab/QCX/blob/d0efce44315acd34c12d4cf08b70848859a18466/.env.local.example): add `TAVILY_API_KEY` entry with a comment noting the runtime behavior when unset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added API key configuration guide for search functionality setup.

* **Chores**
  * Search functionality is now optional and requires API key configuration to enable. If the API key is not configured, the search tool will be unavailable. All other application features remain fully functional and unaffected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QueueLab/QCX/pull/621?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->