### PR TITLE
fix: remove dead Exa search code path

### DIFF
--- a/lib/agents/tools/search.tsx
+++ b/lib/agents/tools/search.tsx
@@ -1,5 +1,4 @@
 import { createStreamableValue } from 'ai/rsc'
-import Exa from 'exa-js'
 import { tavily } from '@tavily/core'
 import { searchSchema } from '@/lib/schema/search'
 import { Card } from '@/components/ui/card'
@@ -39,22 +38,18 @@ export const searchTool = ({ uiStream, fullResponse }: ToolProps) => ({
     const filledQuery =
       query.length < 5 ? query + ' '.repeat(5 - query.length) : query
     let searchResult
-    const searchAPI: 'tavily' | 'exa' = 'tavily'
     try {
-      searchResult =
-        searchAPI === 'tavily'
-          ? await tavilySearch(
-              filledQuery,
-              max_results,
-              search_depth,
-              include_answer,
-              topic,
-              time_range,
-              include_images,
-              include_image_descriptions,
-              include_raw_content
-            )
-          : await exaSearch(query)
+      searchResult = await tavilySearch(
+        filledQuery,
+        max_results,
+        search_depth,
+        include_answer,
+        topic,
+        time_range,
+        include_images,
+        include_image_descriptions,
+        include_raw_content
+      )
     } catch (error) {
       console.error('Search API error:', error)
       hasError = true
@@ -100,13 +95,4 @@ async function tavilySearch(
   })
 
   return { ...response, results: response.results.reverse() }
-}
-
-async function exaSearch(query: string, maxResults: number = 10): Promise<any> {
-  const apiKey = process.env.EXA_API_KEY
-  const exa = new Exa(apiKey)
-  return exa.searchAndContents(query, {
-    highlights: true,
-    numResults: maxResults
-  })
 }


### PR DESCRIPTION
Follow-up to #621 

`searchAPI` in [`lib/agents/tools/search.tsx:42`](https://github.com/QueueLab/QCX/blob/d0efce44315acd34c12d4cf08b70848859a18466/lib/agents/tools/search.tsx#L42) is hardcoded to `'tavily'`, so the Exa fallback branch and its `EXA_API_KEY` env reference are never executed at runtime.

## Key Changes
- [`lib/agents/tools/search.tsx`](https://github.com/QueueLab/QCX/blob/d0efce44315acd34c12d4cf08b70848859a18466/lib/agents/tools/search.tsx): remove unused `import Exa from 'exa-js'`, the dead `searchAPI` ternary branch, and the `exaSearch` function.