### PR TITLE
chore(env): remove upstash, fix env vars, and untrack committed .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-DATABASE_URL="postgresql://user:password@host:port/db"

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,27 +1,46 @@
 # Composio Mapbox Integration
-# Replace with your actual Composio auth config ID, user ID, and API key
 COMPOSIO_API_KEY=your_composio_api_key
 COMPOSIO_MAPBOX_AUTH_CONFIG_ID=ac_YOUR_MAPBOX_CONFIG_ID
 COMPOSIO_USER_ID=user@example.com
 
 # Mapbox Access Token
 MAPBOX_ACCESS_TOKEN=your_mapbox_api_key
+NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN=your_mapbox_public_token_here
 
-# For client-side usage (if needed)
-NEXT_PUBLIC_COMPOSIO_API_KEY=your_composio_api_key
-NEXT_PUBLIC_COMPOSIO_MAPBOX_AUTH_CONFIG_ID=ac_YOUR_MAPBOX_CONFIG_ID
-NEXT_PUBLIC_COMPOSIO_USER_ID=user@example.com
-
-# NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN is already used by mapbox-map.tsx
-# Ensure it's also in your .env.local file if you haven't set it up yet.
-# NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN=your_mapbox_public_token_here
+# Google Maps
+NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=your_google_maps_api_key
+GOOGLE_MAPS_API_KEY=your_google_maps_api_key
 
 # AI Provider API Keys
+# xAI API key retrieved here: https://console.x.ai/
+XAI_API_KEY=your_xai_api_key
+OPENAI_API_KEY=your_openai_api_key
 # Gemini 3.1 Pro (Google Generative AI)
 GEMINI_3_PRO_API_KEY=your_gemini_3_pro_api_key_here
+# Tavily API key retrieved here: https://app.tavily.com/home
+TAVILY_API_KEY=your_tavily_api_key
+EXA_API_KEY=your_exa_api_key
+SERPER_API_KEY=your_serper_api_key
+
+# AWS / Bedrock
+AWS_ACCESS_KEY_ID=your_aws_access_key_id
+AWS_SECRET_ACCESS_KEY=your_aws_secret_access_key
+AWS_REGION=us-east-1
+BEDROCK_MODEL_ID=anthropic.claude-3-5-sonnet-20241022-v2:0
+
+# GCP / AlphaEarth Embeddings
+GCP_PROJECT_ID=your_gcp_project_id
+GCP_CREDENTIALS_PATH=/path/to/gcp_credentials.json
+AEF_INDEX_PATH=./aef_index.csv
 
 # Supabase Credentials
 NEXT_PUBLIC_SUPABASE_URL=YOUR_SUPABASE_URL_HERE
 NEXT_PUBLIC_SUPABASE_ANON_KEY=YOUR_SUPABASE_ANON_KEY_HERE
 SUPABASE_SERVICE_ROLE_KEY=YOUR_SUPABASE_SERVICE_ROLE_KEY_HERE
 DATABASE_URL=postgresql://postgres:[YOUR-POSTGRES-PASSWORD]@[YOUR-SUPABASE-DB-HOST]:[PORT]/postgres
+
+# Feature Flags
+AUTH_DISABLED_FOR_DEV=false
+ENABLE_SHARE=false
+USE_SPECIFIC_API_FOR_WRITER=false
+EXECUTE_MIGRATIONS=false

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
+.env
 .env*.local
 
 # log files

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ https://deepwiki.com/QueueLab/QCX
 - Text streaming / Generative UI: [Vercel AI SDK](https://sdk.vercel.ai/docs)
 - Generative Model [Varies](https://openai.com/)
 - Search API: [Tavily AI](https://tavily.com/) / [Exa AI](https://exa.ai/)
-- Serverless Database: [Upstash](https://upstash.com/)
 - Component library: [shadcn/ui](https://ui.shadcn.com/)
 - Headless component primitives: [Radix UI](https://www.radix-ui.com/)
 - Styling: [Tailwind CSS](https://tailwindcss.com/)
@@ -50,31 +49,32 @@ bun run build
 bun run dev
 ```
 
-### 3. Setting up Upstash Redis
-
-Follow the guide below to set up Upstash Redis. Create a database and obtain `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN`. Refer to the [Upstash guide](https://upstash.com/blog/rag-chatbot-upstash#setting-up-upstash-redis) for instructions on how to proceed.
-
-### 4. Fill out secrets
+### 3. Fill out secrets
 
 ```
 cp .env.local.example .env.local
 ```
 
-Your .env.local file should look like this:
+Your `.env.local` file should look like this:
 
 ```
-# XAI API key retrieved here: https://platform.openai.com/api-keys
+# xAI API key retrieved here: https://console.x.ai/
 XAI_API_KEY=
 
 # Tavily API Key retrieved here: https://app.tavily.com/home
 TAVILY_API_KEY=
 
-# Upstash Redis URL and Token retrieved here: https://console.upstash.com/redis
-UPSTASH_REDIS_REST_URL=
-UPSTASH_REDIS_REST_TOKEN=
-#Mapbox access token
-NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN
+# Mapbox access token
+NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN=
+
+# Supabase
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
+DATABASE_URL=
 ```
+
+See `.env.local.example` for the full list of variables including optional providers (OpenAI, AWS Bedrock, Google Maps, Serper, Exa, GCP).
 
 
 
@@ -82,7 +82,7 @@ NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN
 
 _Note: This project focuses on Generative UI and requires complex output from LLMs. Currently, it's assumed that the official state of the art models will be used. Although it's possible to set up other models, if you use an Standard-compatible model, but we don't guarantee that it'll work._
 
-### 5. Run app locally
+### 4. Run app locally
 
 ```
 bun run dev

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "QCX",
@@ -38,7 +39,6 @@
         "@turf/turf": "^7.2.0",
         "@types/mapbox__mapbox-gl-draw": "^1.4.8",
         "@types/pg": "^8.15.4",
-        "@upstash/redis": "^1.35.0",
         "@vercel/analytics": "^1.5.0",
         "@vercel/speed-insights": "^1.2.0",
         "@vis.gl/react-google-maps": "^1.7.1",
@@ -1044,8 +1044,6 @@
     "@unrs/resolver-binding-win32-ia32-msvc": ["@unrs/resolver-binding-win32-ia32-msvc@1.11.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ=="],
 
     "@unrs/resolver-binding-win32-x64-msvc": ["@unrs/resolver-binding-win32-x64-msvc@1.11.1", "", { "os": "win32", "cpu": "x64" }, "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g=="],
-
-    "@upstash/redis": ["@upstash/redis@1.36.1", "", { "dependencies": { "uncrypto": "^0.1.3" } }, "sha512-N6SjDcgXdOcTAF+7uNoY69o7hCspe9BcA7YjQdxVu5d25avljTwyLaHBW3krWjrP0FfocgMk94qyVtQbeDp39A=="],
 
     "@vercel/analytics": ["@vercel/analytics@1.6.1", "", { "peerDependencies": { "@remix-run/react": "^2", "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@remix-run/react", "@sveltejs/kit", "next", "react", "svelte", "vue", "vue-router"] }, "sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg=="],
 
@@ -2418,8 +2416,6 @@
     "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
 
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
-
-    "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "@turf/turf": "^7.2.0",
     "@types/mapbox__mapbox-gl-draw": "^1.4.8",
     "@types/pg": "^8.15.4",
-    "@upstash/redis": "^1.35.0",
     "@vercel/analytics": "^1.5.0",
     "@vercel/speed-insights": "^1.2.0",
     "@vis.gl/react-google-maps": "^1.7.1",


### PR DESCRIPTION
## Summary

  - Remove `@upstash/redis` package dependency (no longer used in the codebase)
  - Rewrite `.env.local.example` to reflect all variables actually referenced in code , adds `XAI_API_KEY`, `OPENAI_API_KEY`,     `TAVILY_API_KEY`, `EXA_API_KEY`, `SERPER_API_KEY`, 
  - Drops unused    `NEXT_PUBLIC_COMPOSIO_*` variants
  - Fixes `XAI_API_KEY` source comment from `platform.openai.com` -> `console.x.ai`  
  - Update README: remove Upstash from the stack list and setup steps, renumber steps, and update the secrets snippet to match the actual required variables
  - Add `.env` to `.gitignore` and untrack the committed `.env` file (contained a generic `DATABASE_URL` placeholder but `.env` files should not be committed)

Fixes QueueLab/QCX#619

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions and environment variable templates in configuration examples.

* **Chores**
  * Removed Upstash Redis dependency.
  * Updated environment configuration structure with new API provider templates and git ignore patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QueueLab/QCX/pull/623?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->