### PR TITLE
Feat/glassmorphic preview

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "QCX",
@@ -55,7 +56,6 @@
         "exa-js": "^1.6.13",
         "framer-motion": "^12.23.24",
         "geotiff": "^2.1.4-beta.1",
-        "glassmorphic": "^0.0.3",
         "katex": "^0.16.22",
         "lodash": "^4.17.21",
         "lottie-react": "^2.4.1",
@@ -1520,8 +1520,6 @@
     "get-tsconfig": ["get-tsconfig@4.13.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ=="],
 
     "gl-matrix": ["gl-matrix@3.4.4", "", {}, "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ=="],
-
-    "glassmorphic": ["glassmorphic@0.0.3", "", {}, "sha512-sbobZNaKuyup+X450P1brVofyXvl7flXdPGj8UyjvXdT3YXNYTWm3idk/dTcK0YxzhY0igk9t8e1UITP/vNAAw=="],
 
     "glob": ["glob@10.3.10", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^2.3.5", "minimatch": "^9.0.1", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0", "path-scurry": "^1.10.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g=="],
 

--- a/components/resolution-image.tsx
+++ b/components/resolution-image.tsx
@@ -27,7 +27,7 @@ export function ResolutionImage({ src, className, alt = 'Map Imagery' }: Resolut
       <Dialog>
         <DialogTrigger asChild>
           <motion.div
-            className="w-fit cursor-pointer relative glassmorphic overflow-hidden rounded-lg border bg-muted"
+            className="w-fit cursor-pointer relative bg-background/80 backdrop-blur-md border border-border/30 overflow-hidden rounded-lg"
             whileHover={{ scale: 1.02 }}
             whileTap={{ scale: 0.98 }}
           >
@@ -42,7 +42,7 @@ export function ResolutionImage({ src, className, alt = 'Map Imagery' }: Resolut
             </Card>
           </motion.div>
         </DialogTrigger>
-        <DialogContent className="sm:max-w-5xl max-h-[90vh] p-1 glassmorphic border-none">
+        <DialogContent className="sm:max-w-5xl max-h-[90vh] p-1 z-[70] bg-background/80 backdrop-blur-md">
           <DialogHeader className="sr-only">
             <DialogTitle>{alt}</DialogTitle>
           </DialogHeader>

--- a/components/search-results-image.tsx
+++ b/components/search-results-image.tsx
@@ -66,7 +66,7 @@ export const SearchResultsImageSection: React.FC<
         <Dialog key={index}>
           <DialogTrigger asChild>
             <motion.div
-              className="w-[calc(50%-0.5rem)] md:w-[calc(25%-0.5rem)] aspect-video cursor-pointer relative bg-background/80 backdrop-blur-md border border-border/30"
+              className="w-[calc(50%_-_0.5rem)] md:w-[calc(25%_-_0.5rem)] aspect-video cursor-pointer relative bg-background/80 backdrop-blur-md border border-border/30"
               onClick={() => setSelectedIndex(index)}
               whileHover={{ scale: 1.05 }}
               whileTap={{ scale: 0.95 }}

--- a/components/search-results-image.tsx
+++ b/components/search-results-image.tsx
@@ -21,7 +21,6 @@ import {
 import { useEffect, useState } from 'react'
 import { PlusCircle } from 'lucide-react'
 import { motion } from 'framer-motion'
-import 'glassmorphic/glassmorphic.css'
 
 interface SearchResultsImageSectionProps {
   images: string[]
@@ -67,7 +66,7 @@ export const SearchResultsImageSection: React.FC<
         <Dialog key={index}>
           <DialogTrigger asChild>
             <motion.div
-              className="w-[calc(50%-0.5rem)] md:w-[calc(25%-0.5rem)] aspect-video cursor-pointer relative glassmorphic"
+              className="w-[calc(50%-0.5rem)] md:w-[calc(25%-0.5rem)] aspect-video cursor-pointer relative bg-background/80 backdrop-blur-md border border-border/30"
               onClick={() => setSelectedIndex(index)}
               whileHover={{ scale: 1.05 }}
               whileTap={{ scale: 0.95 }}
@@ -95,7 +94,7 @@ export const SearchResultsImageSection: React.FC<
               )}
             </motion.div>
           </DialogTrigger>
-          <DialogContent className="sm:max-w-3xl max-h-[80vh] overflow-auto glassmorphic">
+          <DialogContent className="sm:max-w-3xl max-h-[80vh] overflow-auto z-[70] bg-background/80 backdrop-blur-md border border-border/30">
             <DialogHeader>
               <DialogTitle>Search Images</DialogTitle>
               <DialogDescription className="text-sm">{query}</DialogDescription>

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "exa-js": "^1.6.13",
     "framer-motion": "^12.23.24",
     "geotiff": "^2.1.4-beta.1",
-    "glassmorphic": "^0.0.3",
     "katex": "^0.16.22",
     "lodash": "^4.17.21",
     "lottie-react": "^2.4.1",


### PR DESCRIPTION
## Summary

Fix image preview dialog visibility and styling by replacing unreliable external glassmorphic CSS package with native Tailwind CSS utilities and resolving z-index conflicts.

**components/search-results-image.tsx:**
- Remove `import 'glassmorphic/glassmorphic.css'` statement
- Replace `glassmorphic` class on image thumbnail containers with native Tailwind: `bg-background/80 backdrop-blur-md border border-border/30`
- Update DialogContent to include `z-[70]` with new Tailwind glassmorphic classes to ensure visibility above header

**components/resolution-image.tsx:**
- Replace `glassmorphic` class on image container with native Tailwind: `bg-background/80 backdrop-blur-md border border-border/30`
- Update DialogContent to include `z-[70]` and glassmorphic Tailwind classes

**package.json:**
- Remove `glassmorphic` dependency (^0.0.3)


Fixes #376 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated visual styling for image tiles and enlarged-image dialogs to use consistent background opacity, blur, border, and rounded/overflow behavior.
* **Chores**
  * Removed the now-unused "glassmorphic" styling dependency and migrated components to utility-based styling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QueueLab/QCX/pull/624?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->