### PR TITLE
Fix build crash when DATABASE_URL is missing

### DIFF
--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -5,16 +5,18 @@ import * as schema from './schema';
 
 dotenv.config({ path: '.env.local' });
 
-if (!process.env.DATABASE_URL) {
-  throw new Error('DATABASE_URL environment variable is not set for Drizzle client');
+const databaseUrl = process.env.DATABASE_URL;
+
+if (!databaseUrl) {
+  console.warn('Warning: DATABASE_URL environment variable is not set for Drizzle client.');
 }
 
 const poolConfig: PoolConfig = {
-  connectionString: process.env.DATABASE_URL,
+  connectionString: databaseUrl,
 };
 
 // Conditionally apply SSL for Supabase URLs
-if (process.env.DATABASE_URL && process.env.DATABASE_URL.includes('supabase.co')) {
+if (databaseUrl && databaseUrl.includes('supabase.co')) {
   poolConfig.ssl = {
     rejectUnauthorized: false,
   };


### PR DESCRIPTION
Modified `lib/db/index.ts` to log a warning instead of throwing an error when `DATABASE_URL` is missing. This prevents Next.js 15 builds from failing during the static optimization/prerendering phase when environment variables might not be provided. Verified by running `bun run build` successfully.

---
*PR created automatically by Jules for task [3849659969368994164](https://jules.google.com/task/3849659969368994164) started by @ngoiyaeric*