### PR TITLE
PDF Report Generation with HTML Styling

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -56,6 +56,8 @@
         "framer-motion": "^12.23.24",
         "geotiff": "^2.1.4-beta.1",
         "glassmorphic": "^0.0.3",
+        "html2canvas": "^1.4.1",
+        "jspdf": "^4.2.1",
         "katex": "^0.16.22",
         "lodash": "^4.17.21",
         "lottie-react": "^2.4.1",
@@ -199,7 +201,7 @@
 
     "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.2.3", "", {}, "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw=="],
 
-    "@babel/runtime": ["@babel/runtime@7.28.4", "", {}, "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ=="],
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
     "@borewit/text-codec": ["@borewit/text-codec@0.2.1", "", {}, "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw=="],
 
@@ -959,11 +961,15 @@
 
     "@types/node-fetch": ["@types/node-fetch@2.6.13", "", { "dependencies": { "@types/node": "*", "form-data": "^4.0.4" } }, "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw=="],
 
+    "@types/pako": ["@types/pako@2.0.4", "", {}, "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw=="],
+
     "@types/pbf": ["@types/pbf@3.0.5", "", {}, "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA=="],
 
     "@types/pg": ["@types/pg@8.16.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ=="],
 
     "@types/phoenix": ["@types/phoenix@1.6.7", "", {}, "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q=="],
+
+    "@types/raf": ["@types/raf@3.4.3", "", {}, "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw=="],
 
     "@types/react": ["@types/react@19.2.8", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg=="],
 
@@ -976,6 +982,8 @@
     "@types/tough-cookie": ["@types/tough-cookie@4.0.5", "", {}, "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="],
 
     "@types/triple-beam": ["@types/triple-beam@1.3.5", "", {}, "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="],
+
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
     "@types/tz-lookup": ["@types/tz-lookup@6.1.2", "", {}, "sha512-9y31Xf/8FHXrCHjvVjGZLcsayAa6ABNc8bZlk6MPOQLLlr41tICSqW3TRPRIx2nodbzdKs5N7ipHWBrUsWUiAA=="],
 
@@ -1131,6 +1139,8 @@
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
+    "base64-arraybuffer": ["base64-arraybuffer@1.0.2", "", {}, "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ=="],
+
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
@@ -1168,6 +1178,8 @@
     "camelcase-css": ["camelcase-css@2.0.1", "", {}, "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001764", "", {}, "sha512-9JGuzl2M+vPL+pz70gtMF9sHdMFbY9FJaQBi186cHKH3pSzDvzoUJUPV6fqiKIMyXbud9ZLg4F3Yza1vJ1+93g=="],
+
+    "canvg": ["canvg@3.0.11", "", { "dependencies": { "@babel/runtime": "^7.12.5", "@types/raf": "^3.4.0", "core-js": "^3.8.3", "raf": "^3.4.1", "regenerator-runtime": "^0.13.7", "rgbcolor": "^1.0.1", "stackblur-canvas": "^2.0.0", "svg-pathdata": "^6.0.3" } }, "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
@@ -1237,6 +1249,8 @@
 
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
+    "core-js": ["core-js@3.49.0", "", {}, "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg=="],
+
     "cors": ["cors@2.8.5", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g=="],
 
     "cross-env": ["cross-env@7.0.3", "", { "dependencies": { "cross-spawn": "^7.0.1" }, "bin": { "cross-env": "src/bin/cross-env.js", "cross-env-shell": "src/bin/cross-env-shell.js" } }, "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw=="],
@@ -1244,6 +1258,8 @@
     "cross-fetch": ["cross-fetch@4.1.0", "", { "dependencies": { "node-fetch": "^2.7.0" } }, "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "css-line-break": ["css-line-break@2.1.0", "", { "dependencies": { "utrie": "^1.0.2" } }, "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w=="],
 
     "csscolorparser": ["csscolorparser@1.0.3", "", {}, "sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w=="],
 
@@ -1308,6 +1324,8 @@
     "dlv": ["dlv@1.1.3", "", {}, "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="],
 
     "doctrine": ["doctrine@3.0.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w=="],
+
+    "dompurify": ["dompurify@3.4.7", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA=="],
 
     "dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
@@ -1432,6 +1450,8 @@
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fast-png": ["fast-png@6.4.0", "", { "dependencies": { "@types/pako": "^2.0.3", "iobuffer": "^5.3.2", "pako": "^2.1.0" } }, "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q=="],
 
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
@@ -1585,6 +1605,8 @@
 
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
 
+    "html2canvas": ["html2canvas@1.4.1", "", { "dependencies": { "css-line-break": "^2.1.0", "text-segmentation": "^1.0.3" } }, "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA=="],
+
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
     "http-proxy-agent": ["http-proxy-agent@5.0.0", "", { "dependencies": { "@tootallnate/once": "2", "agent-base": "6", "debug": "4" } }, "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w=="],
@@ -1616,6 +1638,8 @@
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
 
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
+
+    "iobuffer": ["iobuffer@5.4.0", "", {}, "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
@@ -1738,6 +1762,8 @@
     "json5": ["json5@1.0.2", "", { "dependencies": { "minimist": "^1.2.0" }, "bin": { "json5": "lib/cli.js" } }, "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA=="],
 
     "jsondiffpatch": ["jsondiffpatch@0.6.0", "", { "dependencies": { "@types/diff-match-patch": "^1.0.36", "chalk": "^5.3.0", "diff-match-patch": "^1.0.5" }, "bin": { "jsondiffpatch": "bin/jsondiffpatch.js" } }, "sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ=="],
+
+    "jspdf": ["jspdf@4.2.1", "", { "dependencies": { "@babel/runtime": "^7.28.6", "fast-png": "^6.2.0", "fflate": "^0.8.1" }, "optionalDependencies": { "canvg": "^3.0.11", "core-js": "^3.6.0", "dompurify": "^3.3.1", "html2canvas": "^1.0.0-rc.5" } }, "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ=="],
 
     "jsts": ["jsts@2.7.1", "", {}, "sha512-x2wSZHEBK20CY+Wy+BPE7MrFQHW6sIsdaGUMEqmGAio+3gFzQaBYPwLRonUfQf9Ak8pBieqj9tUofX1+WtAEIg=="],
 
@@ -2021,6 +2047,8 @@
 
     "pbf": ["pbf@4.0.1", "", { "dependencies": { "resolve-protobuf-schema": "^2.1.0" }, "bin": { "pbf": "bin/pbf" } }, "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA=="],
 
+    "performance-now": ["performance-now@2.1.0", "", {}, "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="],
+
     "pg": ["pg@8.16.3", "", { "dependencies": { "pg-connection-string": "^2.9.1", "pg-pool": "^3.10.1", "pg-protocol": "^1.10.3", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.2.7" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw=="],
 
     "pg-cloudflare": ["pg-cloudflare@1.2.7", "", {}, "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg=="],
@@ -2113,6 +2141,8 @@
 
     "radix-ui": ["radix-ui@1.4.3", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-accessible-icon": "1.1.7", "@radix-ui/react-accordion": "1.2.12", "@radix-ui/react-alert-dialog": "1.1.15", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-aspect-ratio": "1.1.7", "@radix-ui/react-avatar": "1.1.10", "@radix-ui/react-checkbox": "1.3.3", "@radix-ui/react-collapsible": "1.1.12", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-context-menu": "2.2.16", "@radix-ui/react-dialog": "1.1.15", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-dropdown-menu": "2.1.16", "@radix-ui/react-focus-guards": "1.1.3", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-form": "0.1.8", "@radix-ui/react-hover-card": "1.1.15", "@radix-ui/react-label": "2.1.7", "@radix-ui/react-menu": "2.1.16", "@radix-ui/react-menubar": "1.1.16", "@radix-ui/react-navigation-menu": "1.2.14", "@radix-ui/react-one-time-password-field": "0.1.8", "@radix-ui/react-password-toggle-field": "0.1.3", "@radix-ui/react-popover": "1.1.15", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-progress": "1.1.7", "@radix-ui/react-radio-group": "1.3.8", "@radix-ui/react-roving-focus": "1.1.11", "@radix-ui/react-scroll-area": "1.2.10", "@radix-ui/react-select": "2.2.6", "@radix-ui/react-separator": "1.1.7", "@radix-ui/react-slider": "1.3.6", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-switch": "1.2.6", "@radix-ui/react-tabs": "1.1.13", "@radix-ui/react-toast": "1.2.15", "@radix-ui/react-toggle": "1.1.10", "@radix-ui/react-toggle-group": "1.1.11", "@radix-ui/react-toolbar": "1.1.11", "@radix-ui/react-tooltip": "1.2.8", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-effect-event": "0.0.2", "@radix-ui/react-use-escape-keydown": "1.1.1", "@radix-ui/react-use-is-hydrated": "0.1.0", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/react-visually-hidden": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA=="],
 
+    "raf": ["raf@3.4.1", "", { "dependencies": { "performance-now": "^2.1.0" } }, "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA=="],
+
     "ramda": ["ramda@0.29.1", "", {}, "sha512-OfxIeWzd4xdUNxlWhgFazxsA/nl3mS4/jGZI5n00uWOoSSFRhC1b6gl6xvmzUamgmqELraWp0J/qqVlXYPDPyA=="],
 
     "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
@@ -2153,6 +2183,8 @@
 
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 
+    "regenerator-runtime": ["regenerator-runtime@0.13.11", "", {}, "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="],
+
     "regexp.prototype.flags": ["regexp.prototype.flags@1.5.4", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-errors": "^1.3.0", "get-proto": "^1.0.1", "gopd": "^1.2.0", "set-function-name": "^2.0.2" } }, "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA=="],
 
     "rehype-external-links": ["rehype-external-links@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@ungap/structured-clone": "^1.0.0", "hast-util-is-element": "^3.0.0", "is-absolute-url": "^4.0.0", "space-separated-tokens": "^2.0.0", "unist-util-visit": "^5.0.0" } }, "sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw=="],
@@ -2188,6 +2220,8 @@
     "retry-request": ["retry-request@7.0.2", "", { "dependencies": { "@types/request": "^2.48.8", "extend": "^3.0.2", "teeny-request": "^9.0.0" } }, "sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w=="],
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
+    "rgbcolor": ["rgbcolor@1.0.1", "", {}, "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw=="],
 
     "rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
 
@@ -2275,6 +2309,8 @@
 
     "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
 
+    "stackblur-canvas": ["stackblur-canvas@2.7.0", "", {}, "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ=="],
+
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
@@ -2335,6 +2371,8 @@
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
+    "svg-pathdata": ["svg-pathdata@6.0.3", "", {}, "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw=="],
+
     "sweepline-intersections": ["sweepline-intersections@1.5.0", "", { "dependencies": { "tinyqueue": "^2.0.0" } }, "sha512-AoVmx72QHpKtItPu72TzFL+kcYjd67BPLDoR0LarIk+xyaRg+pDTMFXndIEvZf9xEKnJv6JdhgRMnocoG0D3AQ=="],
 
     "swr": ["swr@2.3.8", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-gaCPRVoMq8WGDcWj9p4YWzCMPHzE0WNl6W8ADIx9c3JBEIdMkJGMzW+uzXvxHMltwcYACr9jP+32H8/hgwMR7w=="],
@@ -2348,6 +2386,8 @@
     "teeny-request": ["teeny-request@9.0.0", "", { "dependencies": { "http-proxy-agent": "^5.0.0", "https-proxy-agent": "^5.0.0", "node-fetch": "^2.6.9", "stream-events": "^1.0.5", "uuid": "^9.0.0" } }, "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g=="],
 
     "text-hex": ["text-hex@1.0.0", "", {}, "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="],
+
+    "text-segmentation": ["text-segmentation@1.0.3", "", { "dependencies": { "utrie": "^1.0.2" } }, "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw=="],
 
     "text-table": ["text-table@0.2.0", "", {}, "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="],
 
@@ -2464,6 +2504,8 @@
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "utrie": ["utrie@1.0.2", "", { "dependencies": { "base64-arraybuffer": "^1.0.2" } }, "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw=="],
 
     "uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
@@ -2744,6 +2786,8 @@
     "rbush/quickselect": ["quickselect@2.0.0", "", {}, "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="],
 
     "react-reconciler/scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
+
+    "react-textarea-autosize/@babel/runtime": ["@babel/runtime@7.28.4", "", {}, "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ=="],
 
     "rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 

--- a/components/download-report-button.tsx
+++ b/components/download-report-button.tsx
@@ -1,0 +1,107 @@
+'use client'
+
+import React, { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { FileText, Loader2 } from 'lucide-react'
+import { useAIState } from 'ai/rsc'
+import { useMap } from './map/map-context'
+import { useMapData } from './map/map-data-context'
+import { generatePDFReport } from '@/lib/utils/report-generator'
+import { AI } from '@/app/actions'
+import { toast } from 'sonner'
+import { ReportTemplate } from './report-template'
+import { createPortal } from 'react-dom'
+
+export const DownloadReportButton = () => {
+  const [aiState] = useAIState<typeof AI>()
+  const { map } = useMap()
+  const { mapData } = useMapData()
+  const [isGenerating, setIsGenerating] = useState(false)
+  const [showTemplate, setShowTemplate] = useState(false)
+  const [mapSnapshot, setMapSnapshot] = useState<string | undefined>()
+
+  const handleDownload = async () => {
+    if (!aiState || aiState.messages.length === 0) {
+      toast.error('No conversation to export')
+      return
+    }
+
+    setIsGenerating(true)
+    try {
+      let snapshot: string | undefined
+      if (map) {
+        snapshot = map.getCanvas().toDataURL('image/png')
+        setMapSnapshot(snapshot)
+      }
+
+      setShowTemplate(true)
+
+      // Wait for React to render the template
+      await new Promise(resolve => setTimeout(resolve, 500))
+
+      let chatTitle = 'Untitled Chat'
+      if (aiState.messages.length > 0) {
+        const firstMessage = aiState.messages[0]
+        if (typeof firstMessage.content === 'string') {
+          try {
+            const parsed = JSON.parse(firstMessage.content)
+            chatTitle = parsed.input || firstMessage.content
+          } catch (e) {
+            chatTitle = firstMessage.content
+          }
+        }
+      }
+      const finalTitle = chatTitle.substring(0, 50)
+
+      await generatePDFReport('report-template', finalTitle)
+
+      toast.success('Report generated successfully')
+    } catch (error) {
+      console.error('Failed to generate report:', error)
+      toast.error('Failed to generate report')
+    } finally {
+      setIsGenerating(false)
+      setShowTemplate(false)
+    }
+  }
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={handleDownload}
+        disabled={isGenerating || !aiState || aiState.messages.length === 0}
+        title="Download PDF Report"
+        className="relative"
+      >
+        {isGenerating ? (
+          <Loader2 className="h-[1.2rem] w-[1.2rem] animate-spin" />
+        ) : (
+          <FileText className="h-[1.2rem] w-[1.2rem]" />
+        )}
+        <span className="sr-only">Download Report</span>
+      </Button>
+
+      {showTemplate && createPortal(
+        <div
+          style={{
+            position: 'absolute',
+            left: '-9999px',
+            top: 0,
+            width: '800px',
+            zIndex: -1
+          }}
+        >
+          <ReportTemplate
+            messages={aiState.messages}
+            drawnFeatures={mapData?.drawnFeatures}
+            mapSnapshot={mapSnapshot}
+            chatTitle="QCX Analysis Report"
+          />
+        </div>,
+        document.body
+      )}
+    </>
+  )
+}

--- a/components/download-report-button.tsx
+++ b/components/download-report-button.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { Button } from '@/components/ui/button'
 import { FileText, Loader2 } from 'lucide-react'
 import { useAIState } from 'ai/rsc'
@@ -19,6 +19,12 @@ export const DownloadReportButton = () => {
   const [isGenerating, setIsGenerating] = useState(false)
   const [showTemplate, setShowTemplate] = useState(false)
   const [mapSnapshot, setMapSnapshot] = useState<string | undefined>()
+  const [reportTitle, setReportTitle] = useState('QCX Analysis Report')
+  const [isMounted, setIsMounted] = useState(false)
+
+  useEffect(() => {
+    setIsMounted(true)
+  }, [])
 
   const handleDownload = async () => {
     if (!aiState || aiState.messages.length === 0) {
@@ -27,43 +33,55 @@ export const DownloadReportButton = () => {
     }
 
     setIsGenerating(true)
+    const toastId = toast.loading('Generating report...')
+
     try {
       let snapshot: string | undefined
       if (map) {
-        snapshot = map.getCanvas().toDataURL('image/png')
+        // Use a smaller snapshot if possible, or just the current canvas
+        snapshot = map.getCanvas().toDataURL('image/jpeg', 0.5)
         setMapSnapshot(snapshot)
       }
 
-      setShowTemplate(true)
-
-      // Wait for React to render the template
-      await new Promise(resolve => setTimeout(resolve, 500))
-
+      // Extract title
       let chatTitle = 'Untitled Chat'
       if (aiState.messages.length > 0) {
         const firstMessage = aiState.messages[0]
-        if (typeof firstMessage.content === 'string') {
-          try {
-            const parsed = JSON.parse(firstMessage.content)
-            chatTitle = parsed.input || firstMessage.content
-          } catch (e) {
-            chatTitle = firstMessage.content
-          }
+        const content = typeof firstMessage.content === 'string'
+          ? firstMessage.content
+          : Array.isArray(firstMessage.content)
+            ? (firstMessage.content as any[]).map(p => p.type === 'text' ? p.text : '').join(' ')
+            : ''
+
+        try {
+          const parsed = JSON.parse(content)
+          chatTitle = parsed.input || content
+        } catch (e) {
+          chatTitle = content
         }
       }
-      const finalTitle = chatTitle.substring(0, 50)
+      const finalTitle = (chatTitle || 'QCX Analysis Report').substring(0, 50)
+      setReportTitle(finalTitle)
+
+      setShowTemplate(true)
+
+      // Short delay for React portal to mount
+      await new Promise(resolve => setTimeout(resolve, 800))
 
       await generatePDFReport('report-template', finalTitle)
 
-      toast.success('Report generated successfully')
+      toast.success('Report generated successfully', { id: toastId })
     } catch (error) {
       console.error('Failed to generate report:', error)
-      toast.error('Failed to generate report')
+      toast.error('Failed to generate report', { id: toastId })
     } finally {
       setIsGenerating(false)
       setShowTemplate(false)
+      setMapSnapshot(undefined) // Clear snapshot memory
     }
   }
+
+  if (!isMounted) return null
 
   return (
     <>
@@ -90,14 +108,16 @@ export const DownloadReportButton = () => {
             left: '-9999px',
             top: 0,
             width: '800px',
-            zIndex: -1
+            zIndex: -1,
+            backgroundColor: 'white',
+            color: 'black'
           }}
         >
           <ReportTemplate
             messages={aiState.messages}
             drawnFeatures={mapData?.drawnFeatures}
             mapSnapshot={mapSnapshot}
-            chatTitle="QCX Analysis Report"
+            chatTitle={reportTitle}
           />
         </div>,
         document.body

--- a/components/download-report-button.tsx
+++ b/components/download-report-button.tsx
@@ -33,17 +33,21 @@ export const DownloadReportButton = () => {
     }
 
     setIsGenerating(true)
-    const toastId = toast.loading('Generating report...')
+    const toastId = toast.loading('Preparing report generation...')
 
     try {
       let snapshot: string | undefined
       if (map) {
-        // Use a smaller snapshot if possible, or just the current canvas
-        snapshot = map.getCanvas().toDataURL('image/jpeg', 0.5)
-        setMapSnapshot(snapshot)
+        try {
+          // Use JPEG to keep the data URL smaller and potentially avoid context loss
+          snapshot = map.getCanvas().toDataURL('image/jpeg', 0.6)
+          setMapSnapshot(snapshot)
+        } catch (e) {
+          console.warn('Failed to capture map snapshot', e)
+        }
       }
 
-      // Extract title
+      // Extract title more robustly
       let chatTitle = 'Untitled Chat'
       if (aiState.messages.length > 0) {
         const firstMessage = aiState.messages[0]
@@ -63,21 +67,26 @@ export const DownloadReportButton = () => {
       const finalTitle = (chatTitle || 'QCX Analysis Report').substring(0, 50)
       setReportTitle(finalTitle)
 
+      // Step 1: Render template in portal
       setShowTemplate(true)
 
-      // Short delay for React portal to mount
-      await new Promise(resolve => setTimeout(resolve, 800))
+      // Step 2: Wait for DOM and React to synchronize
+      // Using a longer timeout to ensure large images and complex content are rendered
+      toast.loading('Rendering report elements...', { id: toastId })
+      await new Promise(resolve => setTimeout(resolve, 1500))
 
+      // Step 3: Capture and Generate
+      toast.loading('Capturing styled report...', { id: toastId })
       await generatePDFReport('report-template', finalTitle)
 
       toast.success('Report generated successfully', { id: toastId })
     } catch (error) {
       console.error('Failed to generate report:', error)
-      toast.error('Failed to generate report', { id: toastId })
+      toast.error(`Report generation failed: ${error instanceof Error ? error.message : 'Unknown error'}`, { id: toastId })
     } finally {
       setIsGenerating(false)
       setShowTemplate(false)
-      setMapSnapshot(undefined) // Clear snapshot memory
+      setMapSnapshot(undefined)
     }
   }
 
@@ -101,16 +110,20 @@ export const DownloadReportButton = () => {
         <span className="sr-only">Download Report</span>
       </Button>
 
+      {/* Hidden container for PDF rendering - ensure it's in the DOM with appropriate styles */}
       {showTemplate && createPortal(
         <div
+          id="pdf-render-container"
           style={{
-            position: 'absolute',
-            left: '-9999px',
+            position: 'fixed',
+            left: '-10000px',
             top: 0,
             width: '800px',
-            zIndex: -1,
+            zIndex: -9999,
             backgroundColor: 'white',
-            color: 'black'
+            color: 'black',
+            visibility: 'visible',
+            pointerEvents: 'none'
           }}
         >
           <ReportTemplate

--- a/components/report-template.tsx
+++ b/components/report-template.tsx
@@ -28,71 +28,91 @@ export const ReportTemplate: React.FC<ReportTemplateProps> = ({
     m.type === 'resolution_search_result'
   )
 
+  const renderMessageContent = (content: any): string => {
+    if (typeof content === 'string') {
+      return content
+    }
+    if (Array.isArray(content)) {
+      return content
+        .map(part => {
+          if (typeof part === 'string') return part
+          if (part && typeof part === 'object' && part.type === 'text') return part.text
+          return ''
+        })
+        .join('\n')
+    }
+    return ''
+  }
+
   return (
     <div id="report-template" className="p-8 bg-white text-black font-sans max-w-4xl mx-auto border border-gray-200">
-      <header className="mb-8 border-b-2 border-primary pb-4">
-        <h1 className="text-3xl font-bold text-primary mb-2">{chatTitle}</h1>
+      <header className="mb-8 border-b-2 border-[#1a1a1a] pb-4">
+        <h1 className="text-3xl font-bold mb-2">{chatTitle}</h1>
         <p className="text-gray-600">Generated on: {new Date().toLocaleString()}</p>
       </header>
 
       {mapSnapshot && (
         <section className="mb-10">
-          <h2 className="text-xl font-semibold mb-4 border-l-4 border-primary pl-2">Live Map View</h2>
-          <div className="border rounded-lg overflow-hidden shadow-sm">
-            <img src={mapSnapshot} alt="Map Snapshot" className="w-full h-auto" />
+          <h2 className="text-xl font-semibold mb-4 border-l-4 border-blue-600 pl-2">Live Map View</h2>
+          <div className="border rounded-lg overflow-hidden shadow-sm bg-gray-100 min-h-[200px] flex items-center justify-center">
+            <img src={mapSnapshot} alt="Map Snapshot" className="w-full h-auto block" crossOrigin="anonymous" />
           </div>
         </section>
       )}
 
       <section className="mb-10">
-        <h2 className="text-xl font-semibold mb-6 border-l-4 border-primary pl-2">Conversation History</h2>
+        <h2 className="text-xl font-semibold mb-6 border-l-4 border-blue-600 pl-2">Conversation History</h2>
         <div className="space-y-8">
           {filteredMessages.map((message, index) => {
+            const contentString = renderMessageContent(message.content)
+
             if (message.type === 'input' || message.type === 'input_related') {
               let content = ''
               try {
-                const json = JSON.parse(message.content as string)
-                content = message.type === 'input' ? json.input : json.related_query
+                const json = JSON.parse(contentString)
+                content = message.type === 'input' ? (json.input || contentString) : (json.related_query || contentString)
               } catch (e) {
-                content = message.content as string
+                content = contentString
               }
               return (
-                <div key={index} className="bg-gray-50 p-4 rounded-lg border-l-4 border-blue-500">
+                <div key={index} className="bg-gray-50 p-4 rounded-lg border-l-4 border-blue-400">
                   <p className="text-sm font-bold text-blue-600 mb-1">User Question</p>
                   <p className="text-gray-800 italic">{content}</p>
                 </div>
               )
             } else if (message.type === 'response') {
               return (
-                <div key={index} className="prose prose-sm max-w-none">
+                <div key={index} className="prose prose-sm max-w-none border-b border-gray-100 pb-4">
                   <p className="text-sm font-bold text-green-600 mb-1">AI Response</p>
-                  <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                    {message.content as string}
-                  </ReactMarkdown>
+                  <div className="text-gray-800">
+                    <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                      {contentString}
+                    </ReactMarkdown>
+                  </div>
                 </div>
               )
             } else if (message.type === 'resolution_search_result') {
               try {
-                const result = JSON.parse(message.content as string)
+                const result = JSON.parse(contentString)
                 return (
-                  <div key={index} className="space-y-4">
+                  <div key={index} className="space-y-4 bg-purple-50 p-4 rounded-lg">
                     <p className="text-sm font-bold text-purple-600 mb-1">Analysis Result</p>
                     {result.summary && (
-                      <div className="bg-purple-50 p-4 rounded-lg text-gray-800">
+                      <div className="text-gray-800 mb-4">
                         {result.summary}
                       </div>
                     )}
                     <div className="grid grid-cols-2 gap-4">
                       {result.mapboxImage && (
                         <div className="space-y-1">
-                          <p className="text-xs text-gray-500">Mapbox View</p>
-                          <img src={result.mapboxImage} alt="Mapbox View" className="rounded border w-full" />
+                          <p className="text-[10px] text-gray-500 font-semibold uppercase">Mapbox View</p>
+                          <img src={result.mapboxImage} alt="Mapbox View" className="rounded border border-purple-200 w-full block" crossOrigin="anonymous" />
                         </div>
                       )}
                       {result.googleImage && (
                         <div className="space-y-1">
-                          <p className="text-xs text-gray-500">Google Satellite</p>
-                          <img src={result.googleImage} alt="Google Satellite" className="rounded border w-full" />
+                          <p className="text-[10px] text-gray-500 font-semibold uppercase">Google Satellite</p>
+                          <img src={result.googleImage} alt="Google Satellite" className="rounded border border-purple-200 w-full block" crossOrigin="anonymous" />
                         </div>
                       )}
                     </div>
@@ -120,7 +140,7 @@ export const ReportTemplate: React.FC<ReportTemplateProps> = ({
                 </tr>
               </thead>
               <tbody className="bg-white divide-y divide-gray-200">
-                {drawnFeatures.map((feature, i) => (
+                {drawnFeatures.map((feature) => (
                   <tr key={feature.id}>
                     <td className="px-4 py-2 whitespace-nowrap text-gray-900">{feature.type}</td>
                     <td className="px-4 py-2 whitespace-nowrap text-gray-900">{feature.measurement}</td>

--- a/components/report-template.tsx
+++ b/components/report-template.tsx
@@ -1,0 +1,143 @@
+import React from 'react'
+import { AIMessage } from '@/lib/types'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+
+export interface ReportTemplateProps {
+  messages: AIMessage[]
+  drawnFeatures?: Array<{
+    id: string
+    type: 'Polygon' | 'LineString'
+    measurement: string
+    geometry: any
+  }>
+  mapSnapshot?: string
+  chatTitle: string
+}
+
+export const ReportTemplate: React.FC<ReportTemplateProps> = ({
+  messages,
+  drawnFeatures,
+  mapSnapshot,
+  chatTitle
+}) => {
+  const filteredMessages = messages.filter(m =>
+    m.type === 'input' ||
+    m.type === 'input_related' ||
+    m.type === 'response' ||
+    m.type === 'resolution_search_result'
+  )
+
+  return (
+    <div id="report-template" className="p-8 bg-white text-black font-sans max-w-4xl mx-auto border border-gray-200">
+      <header className="mb-8 border-b-2 border-primary pb-4">
+        <h1 className="text-3xl font-bold text-primary mb-2">{chatTitle}</h1>
+        <p className="text-gray-600">Generated on: {new Date().toLocaleString()}</p>
+      </header>
+
+      {mapSnapshot && (
+        <section className="mb-10">
+          <h2 className="text-xl font-semibold mb-4 border-l-4 border-primary pl-2">Live Map View</h2>
+          <div className="border rounded-lg overflow-hidden shadow-sm">
+            <img src={mapSnapshot} alt="Map Snapshot" className="w-full h-auto" />
+          </div>
+        </section>
+      )}
+
+      <section className="mb-10">
+        <h2 className="text-xl font-semibold mb-6 border-l-4 border-primary pl-2">Conversation History</h2>
+        <div className="space-y-8">
+          {filteredMessages.map((message, index) => {
+            if (message.type === 'input' || message.type === 'input_related') {
+              let content = ''
+              try {
+                const json = JSON.parse(message.content as string)
+                content = message.type === 'input' ? json.input : json.related_query
+              } catch (e) {
+                content = message.content as string
+              }
+              return (
+                <div key={index} className="bg-gray-50 p-4 rounded-lg border-l-4 border-blue-500">
+                  <p className="text-sm font-bold text-blue-600 mb-1">User Question</p>
+                  <p className="text-gray-800 italic">{content}</p>
+                </div>
+              )
+            } else if (message.type === 'response') {
+              return (
+                <div key={index} className="prose prose-sm max-w-none">
+                  <p className="text-sm font-bold text-green-600 mb-1">AI Response</p>
+                  <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                    {message.content as string}
+                  </ReactMarkdown>
+                </div>
+              )
+            } else if (message.type === 'resolution_search_result') {
+              try {
+                const result = JSON.parse(message.content as string)
+                return (
+                  <div key={index} className="space-y-4">
+                    <p className="text-sm font-bold text-purple-600 mb-1">Analysis Result</p>
+                    {result.summary && (
+                      <div className="bg-purple-50 p-4 rounded-lg text-gray-800">
+                        {result.summary}
+                      </div>
+                    )}
+                    <div className="grid grid-cols-2 gap-4">
+                      {result.mapboxImage && (
+                        <div className="space-y-1">
+                          <p className="text-xs text-gray-500">Mapbox View</p>
+                          <img src={result.mapboxImage} alt="Mapbox View" className="rounded border w-full" />
+                        </div>
+                      )}
+                      {result.googleImage && (
+                        <div className="space-y-1">
+                          <p className="text-xs text-gray-500">Google Satellite</p>
+                          <img src={result.googleImage} alt="Google Satellite" className="rounded border w-full" />
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                )
+              } catch (e) {
+                return null
+              }
+            }
+            return null
+          })}
+        </div>
+      </section>
+
+      {drawnFeatures && drawnFeatures.length > 0 && (
+        <section className="mt-10 border-t-2 border-gray-100 pt-6">
+          <h2 className="text-xl font-semibold mb-4 border-l-4 border-orange-500 pl-2">Appendix: Drawn Features & Measurements</h2>
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200 text-sm">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-2 text-left font-medium text-gray-500 uppercase tracking-wider">Type</th>
+                  <th className="px-4 py-2 text-left font-medium text-gray-500 uppercase tracking-wider">Measurement</th>
+                  <th className="px-4 py-2 text-left font-medium text-gray-500 uppercase tracking-wider">Geometry</th>
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-gray-200">
+                {drawnFeatures.map((feature, i) => (
+                  <tr key={feature.id}>
+                    <td className="px-4 py-2 whitespace-nowrap text-gray-900">{feature.type}</td>
+                    <td className="px-4 py-2 whitespace-nowrap text-gray-900">{feature.measurement}</td>
+                    <td className="px-4 py-2 text-gray-500 break-all font-mono text-[10px]">
+                      {JSON.stringify(feature.geometry.coordinates).substring(0, 100)}...
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+
+      <footer className="mt-12 text-center text-gray-400 text-xs border-t pt-4">
+        <p>© {new Date().getFullYear()} QCX - Planet Computer Analysis Report</p>
+      </footer>
+    </div>
+  )
+}

--- a/components/settings/settings-view.tsx
+++ b/components/settings/settings-view.tsx
@@ -4,6 +4,7 @@ import { SettingsSkeleton } from "@/components/settings/components/settings-skel
 import { useProfileToggle, ProfileToggleEnum } from "@/components/profile-toggle-context"
 import { Button } from "@/components/ui/button"
 import { Minus } from "lucide-react"
+import { DownloadReportButton } from "@/components/download-report-button"
 
 export default function SettingsView() {
   const { toggleProfileSection, activeView } = useProfileToggle();
@@ -22,10 +23,13 @@ export default function SettingsView() {
           <h1 className="text-3xl font-bold tracking-tight">Settings</h1>
           <p className="text-muted-foreground">Manage your planetary copilot preferences and user access</p>
         </div>
-        <Button variant="ghost" size="icon" onClick={handleClose}>
-          <Minus className="h-6 w-6" />
-          <span className="sr-only">Close settings</span>
-        </Button>
+        <div className="flex items-center gap-2">
+          <DownloadReportButton />
+          <Button variant="ghost" size="icon" onClick={handleClose}>
+            <Minus className="h-6 w-6" />
+            <span className="sr-only">Close settings</span>
+          </Button>
+        </div>
       </div>
       <Suspense fallback={<SettingsSkeleton />}>
         <Settings initialTab={initialTab} />

--- a/lib/utils/report-generator.ts
+++ b/lib/utils/report-generator.ts
@@ -1,46 +1,69 @@
-import { jsPDF } from 'jspdf'
-import html2canvas from 'html2canvas'
-
 export const generatePDFReport = async (elementId: string, fileName: string) => {
   const element = document.getElementById(elementId)
   if (!element) {
+    console.error(`Element with id ${elementId} not found in the DOM`)
     throw new Error(`Element with id ${elementId} not found`)
   }
 
   try {
+    const [jsPDF, html2canvas] = await Promise.all([
+      import('jspdf').then(mod => mod.jsPDF),
+      import('html2canvas').then(mod => mod.default)
+    ])
+
+    const images = Array.from(element.getElementsByTagName('img'))
+    const imageLoadTimeout = 3000 // 3 seconds timeout
+
+    await Promise.race([
+      Promise.all(
+        images.map(img => {
+          if (img.complete) return Promise.resolve()
+          return new Promise((resolve) => {
+            img.onload = resolve
+            img.onerror = resolve
+            // Fallback for data URLs which might already be loaded
+            if (img.src.startsWith('data:')) setTimeout(resolve, 100)
+          })
+        })
+      ),
+      new Promise(resolve => setTimeout(resolve, imageLoadTimeout))
+    ])
+
     const canvas = await html2canvas(element, {
-      scale: 2, // Higher scale for better quality
-      useCORS: true, // Allow loading images from different domains
+      scale: 1, // Reduced scale for speed
+      useCORS: true,
       logging: false,
-      allowTaint: true
+      allowTaint: true,
+      backgroundColor: '#ffffff',
+      imageTimeout: 5000,
+      removeContainer: true
     })
 
-    const imgData = canvas.toDataURL('image/png')
+    const imgData = canvas.toDataURL('image/jpeg', 0.7)
     const pdf = new jsPDF({
       orientation: 'portrait',
       unit: 'px',
       format: 'a4'
     })
 
-    const imgProps = pdf.getImageProperties(imgData)
     const pdfWidth = pdf.internal.pageSize.getWidth()
-    const pdfHeight = (imgProps.height * pdfWidth) / imgProps.width
+    const pdfHeight = pdf.internal.pageSize.getHeight()
 
-    // Handle multi-page if necessary (though html2canvas captures the whole element)
-    // For simplicity in this implementation, we'll scale it to one page or use multiple pages if it's very long
+    const imgProps = pdf.getImageProperties(imgData)
+    const ratio = imgProps.height / imgProps.width
+    const scaledHeight = pdfWidth * ratio
 
-    let heightLeft = pdfHeight
+    let heightLeft = scaledHeight
     let position = 0
-    const pageHeight = pdf.internal.pageSize.getHeight()
 
-    pdf.addImage(imgData, 'PNG', 0, position, pdfWidth, pdfHeight)
-    heightLeft -= pageHeight
+    pdf.addImage(imgData, 'JPEG', 0, position, pdfWidth, scaledHeight)
+    heightLeft -= pdfHeight
 
     while (heightLeft >= 0) {
-      position = heightLeft - pdfHeight
+      position = heightLeft - scaledHeight
       pdf.addPage()
-      pdf.addImage(imgData, 'PNG', 0, position, pdfWidth, pdfHeight)
-      heightLeft -= pageHeight
+      pdf.addImage(imgData, 'JPEG', 0, position, pdfWidth, scaledHeight)
+      heightLeft -= pdfHeight
     }
 
     pdf.save(`${fileName.replace(/[^a-z0-9]/gi, '_').toLowerCase()}_report.pdf`)

--- a/lib/utils/report-generator.ts
+++ b/lib/utils/report-generator.ts
@@ -1,0 +1,51 @@
+import { jsPDF } from 'jspdf'
+import html2canvas from 'html2canvas'
+
+export const generatePDFReport = async (elementId: string, fileName: string) => {
+  const element = document.getElementById(elementId)
+  if (!element) {
+    throw new Error(`Element with id ${elementId} not found`)
+  }
+
+  try {
+    const canvas = await html2canvas(element, {
+      scale: 2, // Higher scale for better quality
+      useCORS: true, // Allow loading images from different domains
+      logging: false,
+      allowTaint: true
+    })
+
+    const imgData = canvas.toDataURL('image/png')
+    const pdf = new jsPDF({
+      orientation: 'portrait',
+      unit: 'px',
+      format: 'a4'
+    })
+
+    const imgProps = pdf.getImageProperties(imgData)
+    const pdfWidth = pdf.internal.pageSize.getWidth()
+    const pdfHeight = (imgProps.height * pdfWidth) / imgProps.width
+
+    // Handle multi-page if necessary (though html2canvas captures the whole element)
+    // For simplicity in this implementation, we'll scale it to one page or use multiple pages if it's very long
+
+    let heightLeft = pdfHeight
+    let position = 0
+    const pageHeight = pdf.internal.pageSize.getHeight()
+
+    pdf.addImage(imgData, 'PNG', 0, position, pdfWidth, pdfHeight)
+    heightLeft -= pageHeight
+
+    while (heightLeft >= 0) {
+      position = heightLeft - pdfHeight
+      pdf.addPage()
+      pdf.addImage(imgData, 'PNG', 0, position, pdfWidth, pdfHeight)
+      heightLeft -= pageHeight
+    }
+
+    pdf.save(`${fileName.replace(/[^a-z0-9]/gi, '_').toLowerCase()}_report.pdf`)
+  } catch (error) {
+    console.error('Error generating PDF:', error)
+    throw error
+  }
+}

--- a/lib/utils/report-generator.ts
+++ b/lib/utils/report-generator.ts
@@ -1,8 +1,8 @@
 export const generatePDFReport = async (elementId: string, fileName: string) => {
   const element = document.getElementById(elementId)
   if (!element) {
-    console.error(`Element with id ${elementId} not found in the DOM`)
-    throw new Error(`Element with id ${elementId} not found`)
+    console.error(`Element with id ${elementId} not found in the DOM. Full document structure:`, document.body.innerHTML.substring(0, 500))
+    throw new Error(`Element with id ${elementId} not found. Please try again.`)
   }
 
   try {
@@ -12,17 +12,18 @@ export const generatePDFReport = async (elementId: string, fileName: string) => 
     ])
 
     const images = Array.from(element.getElementsByTagName('img'))
-    const imageLoadTimeout = 3000 // 3 seconds timeout
+    const imageLoadTimeout = 5000 // 5 seconds timeout
 
+    // Wait for images to load, but don't block forever
     await Promise.race([
       Promise.all(
         images.map(img => {
           if (img.complete) return Promise.resolve()
           return new Promise((resolve) => {
             img.onload = resolve
-            img.onerror = resolve
-            // Fallback for data URLs which might already be loaded
-            if (img.src.startsWith('data:')) setTimeout(resolve, 100)
+            img.onerror = resolve // Continue even if one image fails
+            // Force a check after a small delay for data URLs
+            if (img.src.startsWith('data:')) setTimeout(resolve, 500)
           })
         })
       ),
@@ -30,16 +31,24 @@ export const generatePDFReport = async (elementId: string, fileName: string) => 
     ])
 
     const canvas = await html2canvas(element, {
-      scale: 1, // Reduced scale for speed
+      scale: 1, // Keep scale low for performance on large reports
       useCORS: true,
       logging: false,
       allowTaint: true,
       backgroundColor: '#ffffff',
-      imageTimeout: 5000,
-      removeContainer: true
+      imageTimeout: 10000,
+      onclone: (clonedDoc) => {
+        // Ensure the cloned element is visible for html2canvas
+        const clonedElement = clonedDoc.getElementById(elementId)
+        if (clonedElement) {
+          clonedElement.style.position = 'static'
+          clonedElement.style.left = '0'
+          clonedElement.style.visibility = 'visible'
+        }
+      }
     })
 
-    const imgData = canvas.toDataURL('image/jpeg', 0.7)
+    const imgData = canvas.toDataURL('image/jpeg', 0.6)
     const pdf = new jsPDF({
       orientation: 'portrait',
       unit: 'px',
@@ -56,9 +65,11 @@ export const generatePDFReport = async (elementId: string, fileName: string) => 
     let heightLeft = scaledHeight
     let position = 0
 
+    // Add first page
     pdf.addImage(imgData, 'JPEG', 0, position, pdfWidth, scaledHeight)
     heightLeft -= pdfHeight
 
+    // Add subsequent pages if content overflows
     while (heightLeft >= 0) {
       position = heightLeft - scaledHeight
       pdf.addPage()

--- a/package.json
+++ b/package.json
@@ -68,6 +68,8 @@
     "framer-motion": "^12.23.24",
     "geotiff": "^2.1.4-beta.1",
     "glassmorphic": "^0.0.3",
+    "html2canvas": "^1.4.1",
+    "jspdf": "^4.2.1",
     "katex": "^0.16.22",
     "lodash": "^4.17.21",
     "lottie-react": "^2.4.1",


### PR DESCRIPTION
This PR implements the requested PDF report generation feature. It uses a React-based template styled with Tailwind CSS, which is then converted to a PDF using html2canvas and jsPDF. The download button is placed in the SettingsView as a document icon. The report includes the full conversation history, map snapshots from the live view and resolution searches, and an appendix for drawn features and measurements.

---
*PR created automatically by Jules for task [18302854165168169137](https://jules.google.com/task/18302854165168169137) started by @ngoiyaeric*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PDF report export: download conversation analysis reports that include AI responses rendered as rich text, search/resolution summaries, drawn map features (appendix table), and live map snapshot; auto-generated titles and timestamps.

* **User Experience**
  * Download control added to settings; one-click generation with loading, success, and error toasts; button disabled while generating or when no conversation exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->