### PR TITLE
Rename "planetary copilot" to "planet computer" and clear example prompts

### DIFF
--- a/components/empty-screen.tsx
+++ b/components/empty-screen.tsx
@@ -1,28 +1,6 @@
 import { Button } from '@/components/ui/button';
-import { Globe, Thermometer, Laptop, HelpCircle } from 'lucide-react';
 
-const exampleMessages = [
-  {
-    heading: 'What is a planet computer?',
-    message: 'What is a planet computer?',
-    icon: Globe
-  },
-  {
-    heading: 'How does climate change affect our experience?',
-    message: 'How does climate change affect our experience?',
-    icon: Thermometer
-  },
-  {
-    heading: 'What is QCX-Terra?',
-    message: 'What is QCX-Terra?',
-    icon: Laptop,
-  },
-  {
-    heading: 'How do I use the computer?',
-    message: 'How do I use the computer?',
-    icon: HelpCircle,
-  },
-];
+const exampleMessages: { heading: string; message: string; icon: any }[] = [];
 
 export function EmptyScreen({
   submitMessage,

--- a/components/settings/components/model-selection-form.tsx
+++ b/components/settings/components/model-selection-form.tsx
@@ -134,7 +134,7 @@ export function ModelSelectionForm({ form }: ModelSelectionFormProps) {
             </RadioGroup>
           </FormControl>
           <FormDescription>
-            Select the AI model that will power your planetary copilot.
+            Select the AI model that will power your planet computer.
             Different models have different capabilities and performance
             characteristics.
           </FormDescription>

--- a/components/settings/components/settings.tsx
+++ b/components/settings/components/settings.tsx
@@ -53,7 +53,7 @@ export type SettingsFormValues = z.infer<typeof settingsFormSchema>
 // Default values
 const defaultValues: Partial<SettingsFormValues> = {
   systemPrompt:
-    "You are a planetary copilot, an AI assistant designed to help users with information about planets, space exploration, and astronomy. Provide accurate, educational, and engaging responses about our solar system and beyond.",
+    "You are a planet computer, an AI assistant designed to help users with information about planets, space exploration, and astronomy. Provide accurate, educational, and engaging responses about our solar system and beyond.",
   selectedModel: "Gemini 3.1 Pro",
   users: [],
 }
@@ -180,7 +180,7 @@ export function Settings({ initialTab = "system-prompt" }: SettingsProps) {
                   <Card>
                     <CardHeader>
                       <CardTitle>System Prompt</CardTitle>
-                      <CardDescription>Customize the behavior and persona of your planetary copilot</CardDescription>
+                      <CardDescription>Customize the behavior and persona of your planet computer</CardDescription>
                     </CardHeader>
                     <CardContent>
                       <SystemPromptForm form={form} />
@@ -192,7 +192,7 @@ export function Settings({ initialTab = "system-prompt" }: SettingsProps) {
                   <Card>
                     <CardHeader>
                       <CardTitle>Model Selection</CardTitle>
-                      <CardDescription>Choose the AI model that powers your planetary copilot</CardDescription>
+                      <CardDescription>Choose the AI model that powers your planet computer</CardDescription>
                     </CardHeader>
                     <CardContent>
                       <ModelSelectionForm form={form} />

--- a/components/settings/components/system-prompt-form.tsx
+++ b/components/settings/components/system-prompt-form.tsx
@@ -19,13 +19,13 @@ export function SystemPromptForm({ form }: SystemPromptFormProps) {
           <FormLabel>System Prompt</FormLabel>
           <FormControl>
             <Textarea
-              placeholder="Enter the system prompt for your planetary copilot..."
+              placeholder="Enter the system prompt for your planet computer..."
               className="min-h-[200px] resize-y"
               {...field}
             />
           </FormControl>
           <FormDescription className="flex justify-between">
-            <span>Define how your copilot should behave and respond to user queries.</span>
+            <span>Define how your planet computer should behave and respond to user queries.</span>
             <span className={characterCount > 1800 ? "text-amber-500" : ""}>{characterCount}/2000</span>
           </FormDescription>
           <FormMessage />

--- a/components/settings/settings-view.tsx
+++ b/components/settings/settings-view.tsx
@@ -20,7 +20,7 @@ export default function SettingsView() {
       <div className="flex justify-between items-center mb-8">
         <div>
           <h1 className="text-3xl font-bold tracking-tight">Settings</h1>
-          <p className="text-muted-foreground">Manage your planetary copilot preferences and user access</p>
+          <p className="text-muted-foreground">Manage your planet computer preferences and user access</p>
         </div>
         <Button variant="ghost" size="icon" onClick={handleClose}>
           <Minus className="h-6 w-6" />


### PR DESCRIPTION
This PR renames "planetary copilot" to "planet computer" across the application's settings and clears the example prompts on the home screen.

Key changes:
- Updated `components/settings/settings-view.tsx`, `components/settings/components/settings.tsx`, `components/settings/components/system-prompt-form.tsx`, and `components/settings/components/model-selection-form.tsx` to use the new terminology.
- Modified `components/empty-screen.tsx` to remove the default example prompts.
- Cleaned up unused imports in `components/empty-screen.tsx`.

---
*PR created automatically by Jules for task [7570214402781183256](https://jules.google.com/task/7570214402781183256) started by @ngoiyaeric*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed default example messages from the interface.

* **Style**
  * Updated branding terminology across settings components and descriptions to reflect new product naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->