### PR TITLE
Fix Docker build by including drizzle directory

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -80,7 +80,6 @@ docker-compose*.yml
 cloudbuild.yaml
 
 # Drizzle
-drizzle/
 
 # Scripts
 install.sh


### PR DESCRIPTION
The Docker build was failing because the drizzle directory was ignored by .dockerignore, but the Dockerfile tried to copy it in the runner stage. This PR removes it from .dockerignore to ensure migration files are available.

---
*PR created automatically by Jules for task [16503710015550010471](https://jules.google.com/task/16503710015550010471) started by @ngoiyaeric*