### PR TITLE
Implement Domain-Based System Prompt Generation

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -24,6 +24,9 @@ GEMINI_3_PRO_API_KEY=your_gemini_3_pro_api_key_here
 # If not set, the `search` tool is skipped and the LLM answers from its own knowledge.
 TAVILY_API_KEY=your_tavily_api_key
 
+# Firecrawl API (https://firecrawl.dev)
+FIRECRAWL_API_KEY=your_firecrawl_api_key
+
 # Supabase Credentials
 NEXT_PUBLIC_SUPABASE_URL=YOUR_SUPABASE_URL_HERE
 NEXT_PUBLIC_SUPABASE_ANON_KEY=YOUR_SUPABASE_ANON_KEY_HERE

--- a/bun.lock
+++ b/bun.lock
@@ -85,6 +85,7 @@
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
         "tz-lookup": "^6.1.25",
+        "undici": "^8.5.0",
         "use-mcp": "^0.0.9",
         "uuid": "^9.0.0",
         "zod": "^3.25.0",
@@ -2467,6 +2468,8 @@
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
 
     "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
+
+    "undici": ["undici@8.5.0", "", {}, "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "@heroicons/react": "^2.2.0",
         "@hookform/resolvers": "3.3.4",
         "@mapbox/mapbox-gl-draw": "^1.5.0",
+        "@mendable/firecrawl-js": "^4.28.3",
         "@modelcontextprotocol/sdk": "^1.13.0",
         "@radix-ui/react-alert-dialog": "^1.1.10",
         "@radix-ui/react-avatar": "^1.1.6",
@@ -398,6 +399,8 @@
     "@mapbox/vector-tile": ["@mapbox/vector-tile@2.0.4", "", { "dependencies": { "@mapbox/point-geometry": "~1.1.0", "@types/geojson": "^7946.0.16", "pbf": "^4.0.1" } }, "sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg=="],
 
     "@mapbox/whoots-js": ["@mapbox/whoots-js@3.1.0", "", {}, "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q=="],
+
+    "@mendable/firecrawl-js": ["@mendable/firecrawl-js@4.28.3", "", { "dependencies": { "axios": "1.18.0", "firecrawl": "4.16.0", "typescript-event-target": "^1.1.1", "zod": "^3.23.8", "zod-to-json-schema": "^3.23.0" } }, "sha512-sXzSC61NoVoVU969+++mXpNp95aQRrfHLCxo5MgpHNZAdsB3YGL3VL8/8K70HFXGi03btSf6RqIy8zQdSmt0lQ=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.2", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww=="],
 
@@ -1131,7 +1134,7 @@
 
     "axe-core": ["axe-core@4.11.1", "", {}, "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A=="],
 
-    "axios": ["axios@1.13.2", "", { "dependencies": { "follow-redirects": "^1.15.6", "form-data": "^4.0.4", "proxy-from-env": "^1.1.0" } }, "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA=="],
+    "axios": ["axios@1.18.0", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
@@ -1477,13 +1480,15 @@
 
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
+    "firecrawl": ["firecrawl@4.16.0", "", { "dependencies": { "axios": "^1.13.5", "typescript-event-target": "^1.1.1", "zod": "^3.23.8", "zod-to-json-schema": "^3.23.0" } }, "sha512-7SJ/FWhZBtW2gTCE/BsvU+gbfIpfTq+D9IH82l9MacauLVptaY6EdYAhrK3YSMC9yr5NxvxRcpZKcXG/nqjiiQ=="],
+
     "flat-cache": ["flat-cache@3.2.0", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.3", "rimraf": "^3.0.2" } }, "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw=="],
 
     "flatted": ["flatted@3.3.3", "", {}, "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="],
 
     "fn.name": ["fn.name@1.1.0", "", {}, "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="],
 
-    "follow-redirects": ["follow-redirects@1.15.11", "", {}, "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="],
+    "follow-redirects": ["follow-redirects@1.16.0", "", {}, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
 
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
 
@@ -2125,7 +2130,7 @@
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
-    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
+    "proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
@@ -2451,6 +2456,8 @@
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
+    "typescript-event-target": ["typescript-event-target@1.1.2", "", {}, "sha512-TvkrTUpv7gCPlcnSoEwUVUBwsdheKm+HF5u2tPAKubkIGMfovdSizCTaZRY/NhR8+Ijy8iZZUapbVQAsNrkFrw=="],
+
     "tz-lookup": ["tz-lookup@6.1.25", "", {}, "sha512-fFewT9o1uDzsW1QnUU1ValqaihFnwiUiiHr1S79/fxOzKXYYvX+EHeRnpvQJ9B3Qg67wPXT6QF2Esc4pFOrvLg=="],
 
     "uglify-js": ["uglify-js@1.3.5", "", { "bin": { "uglifyjs": "./bin/uglifyjs" } }, "sha512-YPX1DjKtom8l9XslmPFQnqWzTBkvI4N0pbkzLuPZZ4QTyig0uQqvZz9NgUdfEV+qccJzi7fVcGWdESvRIjWptQ=="],
@@ -2671,6 +2678,8 @@
 
     "@tailwindcss/typography/postcss-selector-parser": ["postcss-selector-parser@6.0.10", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w=="],
 
+    "@tavily/core/axios": ["axios@1.13.2", "", { "dependencies": { "follow-redirects": "^1.15.6", "form-data": "^4.0.4", "proxy-from-env": "^1.1.0" } }, "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA=="],
+
     "@turf/tesselate/earcut": ["earcut@2.2.4", "", {}, "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="],
 
     "@types/request/form-data": ["form-data@2.5.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.35", "safe-buffer": "^5.2.1" } }, "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A=="],
@@ -2686,6 +2695,8 @@
     "ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@2.2.8", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "nanoid": "^3.3.8", "secure-json-parse": "^2.7.0" }, "peerDependencies": { "zod": "^3.23.8" } }, "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA=="],
 
     "ajv-formats/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
+
+    "axios/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
     "chokidar/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
@@ -2883,11 +2894,17 @@
 
     "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
+    "@tavily/core/axios/follow-redirects": ["follow-redirects@1.15.11", "", {}, "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="],
+
+    "@tavily/core/axios/proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
+
     "@types/request/form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "axios/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
     "cli-table3/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 

--- a/components/settings/components/settings.tsx
+++ b/components/settings/components/settings.tsx
@@ -46,6 +46,7 @@ const settingsFormSchema = z.object({
   ),
   newUserEmail: z.string().email().optional().or(z.literal('')),
   newUserRole: z.enum(["admin", "editor", "viewer"]).optional(),
+  domain: z.string().url().optional().or(z.literal('')),
 })
 
 export type SettingsFormValues = z.infer<typeof settingsFormSchema>
@@ -56,6 +57,7 @@ const defaultValues: Partial<SettingsFormValues> = {
     "You are a planetary copilot, an AI assistant designed to help users with information about planets, space exploration, and astronomy. Provide accurate, educational, and engaging responses about our solar system and beyond.",
   selectedModel: "Gemini 3.1 Pro",
   users: [],
+  domain: "",
 }
 
 interface SettingsProps {

--- a/components/settings/components/system-prompt-form.tsx
+++ b/components/settings/components/system-prompt-form.tsx
@@ -1,36 +1,166 @@
+import React, { useState, useEffect } from 'react'
 import type { UseFormReturn } from "react-hook-form"
 import { FormField, FormItem, FormLabel, FormControl, FormDescription, FormMessage } from "@/components/ui/form"
 import { Textarea } from "@/components/ui/textarea"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import { Loader2, Sparkles } from "lucide-react"
+import { useToast } from "@/components/ui/hooks/use-toast"
+import { startSystemPromptGeneration, getSystemPromptGenerationJob } from "@/lib/actions/system-prompt"
 
 interface SystemPromptFormProps {
   form: UseFormReturn<any>
 }
 
 export function SystemPromptForm({ form }: SystemPromptFormProps) {
+  const { toast } = useToast()
   const systemPrompt = form.watch("systemPrompt")
+  const domain = form.watch("domain")
   const characterCount = systemPrompt?.length || 0
+  const [jobId, setJobId] = useState<string | null>(null)
+  const [isGenerating, setIsGenerating] = useState(false)
+
+  const handleGenerate = async () => {
+    if (!domain) {
+      toast({
+        title: "Domain required",
+        description: "Please enter a domain to generate a system prompt.",
+        variant: "destructive",
+      })
+      return
+    }
+
+    setIsGenerating(true)
+    const result = await startSystemPromptGeneration(domain)
+
+    if (result.error) {
+      toast({
+        title: "Generation failed",
+        description: result.error,
+        variant: "destructive",
+      })
+      setIsGenerating(false)
+    } else if (result.jobId) {
+      setJobId(result.jobId)
+    }
+  }
+
+  useEffect(() => {
+    let interval: NodeJS.Timeout | null = null
+
+    if (jobId) {
+      const pollStartTime = Date.now()
+      const MAX_POLL_DURATION = 120000 // 2 minutes
+
+      interval = setInterval(async () => {
+        const elapsed = Date.now() - pollStartTime
+        if (elapsed > MAX_POLL_DURATION) {
+          if (interval) clearInterval(interval)
+          setJobId(null)
+          setIsGenerating(false)
+          toast({
+            title: "Generation timeout",
+            description: "The prompt generation took too long. Please try again.",
+            variant: "destructive",
+          })
+          return
+        }
+
+        const job = await getSystemPromptGenerationJob(jobId)
+
+        if (job.error || job.status === 'error') {
+          if (interval) clearInterval(interval)
+          setJobId(null)
+          setIsGenerating(false)
+          toast({
+            title: "Generation error",
+            description: job.errorMessage || job.error || "An error occurred during generation.",
+            variant: "destructive",
+          })
+        } else if (job.status === 'complete') {
+          if (interval) clearInterval(interval)
+          setJobId(null)
+          setIsGenerating(false)
+          if (job.resultPrompt) {
+            form.setValue("systemPrompt", job.resultPrompt, { shouldValidate: true, shouldDirty: true })
+            toast({
+              title: "Prompt generated",
+              description: "Your system prompt has been generated based on the domain content.",
+            })
+          }
+        }
+      }, 3000)
+    }
+
+    return () => {
+      if (interval) clearInterval(interval)
+    }
+  }, [jobId, form, toast])
 
   return (
-    <FormField
-      control={form.control}
-      name="systemPrompt"
-      render={({ field, fieldState, formState }: { field: import("react-hook-form").ControllerRenderProps<any, "systemPrompt">; fieldState: import("react-hook-form").ControllerFieldState; formState: import("react-hook-form").UseFormStateReturn<any>; }) => (
-        <FormItem>
-          <FormLabel>System Prompt</FormLabel>
-          <FormControl>
-            <Textarea
-              placeholder="Enter the system prompt for your planetary copilot..."
-              className="min-h-[200px] resize-y"
-              {...field}
-            />
-          </FormControl>
-          <FormDescription className="flex justify-between">
-            <span>Define how your copilot should behave and respond to user queries.</span>
-            <span className={characterCount > 1800 ? "text-amber-500" : ""}>{characterCount}/2000</span>
-          </FormDescription>
-          <FormMessage />
-        </FormItem>
-      )}
-    />
+    <div className="space-y-6">
+      <FormField
+        control={form.control}
+        name="domain"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Business Domain</FormLabel>
+            <div className="flex gap-2">
+              <FormControl>
+                <Input
+                  placeholder="example.com"
+                  {...field}
+                  disabled={isGenerating}
+                />
+              </FormControl>
+              <Button
+                type="button"
+                onClick={handleGenerate}
+                disabled={isGenerating || !domain}
+                className="shrink-0"
+              >
+                {isGenerating ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Generating...
+                  </>
+                ) : (
+                  <>
+                    <Sparkles className="mr-2 h-4 w-4" />
+                    Generate
+                  </>
+                )}
+              </Button>
+            </div>
+            <FormDescription>
+              Enter your business website to automatically generate a tailored system prompt.
+            </FormDescription>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={form.control}
+        name="systemPrompt"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>System Prompt</FormLabel>
+            <FormControl>
+              <Textarea
+                placeholder="Enter the system prompt for your planetary copilot..."
+                className="min-h-[200px] resize-y"
+                {...field}
+              />
+            </FormControl>
+            <FormDescription className="flex justify-between">
+              <span>Define how your copilot should behave and respond to user queries.</span>
+              <span className={characterCount > 1800 ? "text-amber-500" : ""}>{characterCount}/2000</span>
+            </FormDescription>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </div>
   )
 }

--- a/drizzle/migrations/0002_lively_black_widow.sql
+++ b/drizzle/migrations/0002_lively_black_widow.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "prompt_generation_jobs" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"domain" text NOT NULL,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"result_prompt" text,
+	"error_message" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "prompt_generation_jobs" ADD CONSTRAINT "prompt_generation_jobs_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;

--- a/drizzle/migrations/meta/0002_snapshot.json
+++ b/drizzle/migrations/meta/0002_snapshot.json
@@ -1,0 +1,763 @@
+{
+  "id": "fd89f5aa-13b0-4dd4-9f50-4e921eea0f4f",
+  "prevId": "4bf9530d-5baf-49a0-aa5d-7997ed7bc44e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.calendar_notes": {
+      "name": "calendar_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_tags": {
+          "name": "location_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_tags": {
+          "name": "user_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_feature_id": {
+          "name": "map_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "calendar_notes_user_id_users_id_fk": {
+          "name": "calendar_notes_user_id_users_id_fk",
+          "tableFrom": "calendar_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_notes_chat_id_chats_id_fk": {
+          "name": "calendar_notes_chat_id_chats_id_fk",
+          "tableFrom": "calendar_notes",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_participants": {
+      "name": "chat_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'collaborator'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_participants_chat_id_chats_id_fk": {
+          "name": "chat_participants_chat_id_chats_id_fk",
+          "tableFrom": "chat_participants",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_participants_user_id_users_id_fk": {
+          "name": "chat_participants_user_id_users_id_fk",
+          "tableFrom": "chat_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chat_participants_chat_user_unique": {
+          "name": "chat_participants_chat_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chat_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chats": {
+      "name": "chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled Chat'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'private'"
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_path": {
+          "name": "share_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shareable_link_id": {
+          "name": "shareable_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chats_user_id_users_id_fk": {
+          "name": "chats_user_id_users_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chats_shareable_link_id_unique": {
+          "name": "chats_shareable_link_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "shareable_link_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.locations": {
+      "name": "locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geojson": {
+          "name": "geojson",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "geometry": {
+          "name": "geometry",
+          "type": "geometry(GEOMETRY, 4326)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "locations_user_id_users_id_fk": {
+          "name": "locations_user_id_users_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "locations_chat_id_chats_id_fk": {
+          "name": "locations_chat_id_chats_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_chat_id_chats_id_fk": {
+          "name": "messages_chat_id_chats_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_user_id_users_id_fk": {
+          "name": "messages_user_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_location_id_locations_id_fk": {
+          "name": "messages_location_id_locations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prompt_generation_jobs": {
+      "name": "prompt_generation_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "result_prompt": {
+          "name": "result_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_generation_jobs_user_id_users_id_fk": {
+          "name": "prompt_generation_jobs_user_id_users_id_fk",
+          "tableFrom": "prompt_generation_jobs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_prompts": {
+      "name": "system_prompts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "system_prompts_user_id_users_id_fk": {
+          "name": "system_prompts_user_id_users_id_fk",
+          "tableFrom": "system_prompts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'viewer'"
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.visualizations": {
+      "name": "visualizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'map_layer'"
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "geometry": {
+          "name": "geometry",
+          "type": "geometry(GEOMETRY, 4326)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "visualizations_user_id_users_id_fk": {
+          "name": "visualizations_user_id_users_id_fk",
+          "tableFrom": "visualizations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "visualizations_chat_id_chats_id_fk": {
+          "name": "visualizations_chat_id_chats_id_fk",
+          "tableFrom": "visualizations",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1781859708408,
       "tag": "0001_sync_schema_full",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1782395315062,
+      "tag": "0002_lively_black_widow",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/actions/system-prompt-db.ts
+++ b/lib/actions/system-prompt-db.ts
@@ -1,0 +1,51 @@
+import { db } from '@/lib/db';
+import { promptGenerationJobs } from '@/lib/db/schema';
+import { eq, and } from 'drizzle-orm';
+
+export type PromptGenerationJob = typeof promptGenerationJobs.$inferSelect;
+export type NewPromptGenerationJob = typeof promptGenerationJobs.$inferInsert;
+
+/**
+ * Creates a new prompt generation job.
+ */
+export async function createJob(data: NewPromptGenerationJob): Promise<PromptGenerationJob> {
+  const result = await db.insert(promptGenerationJobs).values(data).returning();
+  if (!result[0]) {
+    throw new Error('Failed to create prompt generation job');
+  }
+  return result[0];
+}
+
+/**
+ * Updates an existing prompt generation job.
+ * Automatically advances updatedAt to serve as a heartbeat.
+ */
+export async function updateJob(
+  id: string,
+  userId: string,
+  data: Partial<Omit<NewPromptGenerationJob, 'id' | 'userId' | 'createdAt'>>
+): Promise<PromptGenerationJob | null> {
+  const result = await db
+    .update(promptGenerationJobs)
+    .set({
+      ...data,
+      updatedAt: new Date(),
+    })
+    .where(and(eq(promptGenerationJobs.id, id), eq(promptGenerationJobs.userId, userId)))
+    .returning();
+
+  return result[0] || null;
+}
+
+/**
+ * Fetches a job by ID and userId.
+ */
+export async function getJobByIdAndUserId(id: string, userId: string): Promise<PromptGenerationJob | null> {
+  const result = await db
+    .select()
+    .from(promptGenerationJobs)
+    .where(and(eq(promptGenerationJobs.id, id), eq(promptGenerationJobs.userId, userId)))
+    .limit(1);
+
+  return result[0] || null;
+}

--- a/lib/actions/system-prompt.ts
+++ b/lib/actions/system-prompt.ts
@@ -1,0 +1,136 @@
+'use server';
+
+import { getCurrentUserIdOnServer } from '@/lib/auth/get-current-user';
+import { z } from 'zod';
+import { createJob, updateJob, getJobByIdAndUserId } from './system-prompt-db';
+import { getFirecrawlClient } from '@/lib/agents/tools/firecrawl';
+import { getModel } from '@/lib/utils';
+import { generateText } from 'ai';
+
+const domainSchema = z.string().min(1).refine((val) => {
+  try {
+    // Basic validation to check if it's a valid URL or domain
+    const url = val.startsWith('http') ? val : `https://${val}`;
+    new URL(url);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}, { message: "Invalid domain or URL" });
+
+const STALENESS_THRESHOLD_MS = 1000 * 60 * 5; // 5 minutes
+const WORKER_TIMEOUT_MS = 1000 * 60 * 2; // 2 minutes
+
+export async function startSystemPromptGeneration(domain: string) {
+  const userId = await getCurrentUserIdOnServer();
+  if (!userId) {
+    return { error: 'Unauthorized' };
+  }
+
+  const validation = domainSchema.safeParse(domain);
+  if (!validation.success) {
+    return { error: validation.error.errors[0].message };
+  }
+
+  const normalizedDomain = domain.startsWith('http') ? domain : `https://${domain}`;
+
+  try {
+    const job = await createJob({
+      userId,
+      domain: normalizedDomain,
+      status: 'pending',
+    });
+
+    // Fire and forget background worker
+    runBackgroundWorker(job.id, userId, normalizedDomain).catch(console.error);
+
+    return { jobId: job.id };
+  } catch (error) {
+    console.error('Failed to start system prompt generation:', error);
+    return { error: 'Failed to initiate job' };
+  }
+}
+
+async function runBackgroundWorker(jobId: string, userId: string, domain: string) {
+  const timeoutPromise = new Promise((_, reject) =>
+    setTimeout(() => reject(new Error('Job execution timeout')), WORKER_TIMEOUT_MS)
+  );
+
+  try {
+    await updateJob(jobId, userId, { status: 'processing' });
+
+    const workPromise = (async () => {
+      const firecrawl = getFirecrawlClient();
+      const scrapeResult = await firecrawl.scrapeUrl(domain, {
+        formats: ['markdown'],
+      });
+
+      if (!scrapeResult.success || !scrapeResult.markdown) {
+        throw new Error(scrapeResult.error || 'Failed to scrape content');
+      }
+
+      const content = scrapeResult.markdown;
+      if (content.length < 100) {
+        throw new Error('Insufficient content scraped from domain');
+      }
+
+      const model = await getModel();
+      const { text } = await generateText({
+        model,
+        system: 'You are an expert at creating concise and effective AI system prompts for business copilots.',
+        prompt: `Based on the following content scraped from ${domain}, generate a concise system prompt (10-2000 characters) for an AI business copilot. The prompt should define the business's identity, products/services, tone, and how it should assist users.
+
+        Content:
+        ${content.substring(0, 5000)}`, // Limit content size for LLM
+      });
+
+      const finalPrompt = text.trim();
+      if (finalPrompt.length < 10 || finalPrompt.length > 2000) {
+        throw new Error('Generated prompt is outside the allowed length constraints');
+      }
+
+      await updateJob(jobId, userId, {
+        status: 'complete',
+        resultPrompt: finalPrompt,
+      });
+    })();
+
+    await Promise.race([workPromise, timeoutPromise]);
+  } catch (error: any) {
+    console.error(`Background worker error for job ${jobId}:`, error);
+    await updateJob(jobId, userId, {
+      status: 'error',
+      errorMessage: error.message || 'An unexpected error occurred during generation',
+    });
+  }
+}
+
+export async function getSystemPromptGenerationJob(jobId: string) {
+  const userId = await getCurrentUserIdOnServer();
+  if (!userId) {
+    return { error: 'Unauthorized' };
+  }
+
+  const job = await getJobByIdAndUserId(jobId, userId);
+  if (!job) {
+    return { error: 'Job not found' };
+  }
+
+  // Staleness check
+  if (job.status === 'pending' || job.status === 'processing') {
+    const lastUpdate = new Date(job.updatedAt).getTime();
+    const now = new Date().getTime();
+    if (now - lastUpdate > STALENESS_THRESHOLD_MS) {
+      return {
+        status: 'error',
+        errorMessage: 'Job timed out or was abandoned. Please try again.',
+      };
+    }
+  }
+
+  return {
+    status: job.status,
+    resultPrompt: job.resultPrompt,
+    errorMessage: job.errorMessage,
+  };
+}

--- a/lib/actions/system-prompt.ts
+++ b/lib/actions/system-prompt.ts
@@ -65,8 +65,11 @@ async function runBackgroundWorker(jobId: string, userId: string, domain: string
         formats: ['markdown'],
       });
 
-      if (!scrapeResult.success || !scrapeResult.markdown) {
-        throw new Error(scrapeResult.error || 'Failed to scrape content');
+      // The library's type definitions for scrapeUrl can be complex.
+      // We check for markdown presence to determine success.
+      if (!scrapeResult || !('markdown' in scrapeResult) || !scrapeResult.markdown) {
+        const errorMsg = (scrapeResult as any)?.error || 'Failed to scrape content';
+        throw new Error(errorMsg);
       }
 
       const content = scrapeResult.markdown;

--- a/lib/agents/tools/firecrawl.ts
+++ b/lib/agents/tools/firecrawl.ts
@@ -1,0 +1,9 @@
+import FirecrawlApp from '@mendable/firecrawl-js';
+
+export function getFirecrawlClient() {
+  const apiKey = process.env.FIRECRAWL_API_KEY;
+  if (!apiKey) {
+    throw new Error('FIRECRAWL_API_KEY is not set');
+  }
+  return new FirecrawlApp({ apiKey });
+}

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -111,6 +111,7 @@ export const usersRelations = relations(users, ({ many }) => ({
   systemPrompts: many(systemPrompts),
   locations: many(locations),
   visualizations: many(visualizations),
+  promptGenerationJobs: many(promptGenerationJobs),
 }));
 
 export const chatsRelations = relations(chats, ({ one, many }) => ({
@@ -178,6 +179,24 @@ export const visualizationsRelations = relations(visualizations, ({ one }) => ({
   chat: one(chats, {
     fields: [visualizations.chatId],
     references: [chats.id],
+  }),
+}));
+
+export const promptGenerationJobs = pgTable('prompt_generation_jobs', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  userId: uuid('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
+  domain: text('domain').notNull(),
+  status: text('status').notNull().default('pending'), // pending | processing | complete | error
+  resultPrompt: text('result_prompt'),
+  errorMessage: text('error_message'),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+});
+
+export const promptGenerationJobsRelations = relations(promptGenerationJobs, ({ one }) => ({
+  user: one(users, {
+    fields: [promptGenerationJobs.userId],
+    references: [users.id],
   }),
 }));
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@heroicons/react": "^2.2.0",
     "@hookform/resolvers": "3.3.4",
     "@mapbox/mapbox-gl-draw": "^1.5.0",
+    "@mendable/firecrawl-js": "^4.28.3",
     "@modelcontextprotocol/sdk": "^1.13.0",
     "@radix-ui/react-alert-dialog": "^1.1.10",
     "@radix-ui/react-avatar": "^1.1.6",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
     "tz-lookup": "^6.1.25",
+    "undici": "^8.5.0",
     "use-mcp": "^0.0.9",
     "uuid": "^9.0.0",
     "zod": "^3.25.0",


### PR DESCRIPTION
This PR implements a feature that allows users to generate a system prompt for their AI copilot by providing a business domain URL.

Key changes:
- New `prompt_generation_jobs` table and Drizzle migration to track background work.
- Firecrawl integration for scraping website content.
- A decoupled backend architecture:
  - `startSystemPromptGeneration`: Kickoff action that starts a fire-and-forget worker.
  - `runBackgroundWorker`: Detached async function that handles scraping, LLM generation, and status updates.
  - `getSystemPromptGenerationJob`: Polling action with staleness detection.
- UI updates in the "System Prompt" settings tab:
  - Domain input field with Zod validation.
  - "Generate" button with loading/pending states.
  - Polling loop that updates the system prompt textarea upon completion.
  - Success/error toast notifications.

The feature is built to be resilient to process restarts and provides a smooth user experience through asynchronous progress tracking.

---
*PR created automatically by Jules for task [17443257101179417112](https://jules.google.com/task/17443257101179417112) started by @ngoiyaeric*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Business Domain” field to settings, including a one-click “Generate” option to create a tailored system prompt.
  * System prompt generation now runs as a tracked background job and updates the editor when complete.
  * Added a Firecrawl API key placeholder to the environment example.
* **Bug Fixes**
  * Improved reliability of long-running generation by enforcing a timeout and surfacing clearer success/error states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->