### PR TITLE
Make Zap icon clickable in Purchase Credits popup

### DIFF
--- a/components/purchase-credits-popup.tsx
+++ b/components/purchase-credits-popup.tsx
@@ -23,6 +23,10 @@ export function PurchaseCreditsPopup({ isOpen, onClose }: PurchaseCreditsPopupPr
     onClose();
   };
 
+  const handleZapClick = () => {
+    window.open('https://www.benchmark.queue.cx', '_blank');
+  };
+
   const features = [
     'Resolution Search',
     'Upload and analyze unlimited files',
@@ -37,7 +41,13 @@ export function PurchaseCreditsPopup({ isOpen, onClose }: PurchaseCreditsPopupPr
       <DialogContent className="sm:max-w-[425px]">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <Zap className="text-yellow-500" />
+            <button
+              onClick={handleZapClick}
+              className="hover:opacity-80 transition-opacity cursor-pointer focus:outline-none"
+              aria-label="Upgrade options"
+            >
+              <Zap className="text-yellow-500" />
+            </button>
             Upgrade Your Plan
           </DialogTitle>
           <DialogDescription>


### PR DESCRIPTION
Turned the Zap icon in the Purchase Credits popup into a clickable button that routes to an external URL (https://www.benchmark.queue.cx). The change includes:
- Adding a `handleZapClick` function to open the URL in a new tab.
- Wrapping the `<Zap />` icon in a `<button>` with Tailwind CSS classes for hover effects and focus states.
- Adding an `aria-label` for accessibility.

---
*PR created automatically by Jules for task [10926758883629090417](https://jules.google.com/task/10926758883629090417) started by @ngoiyaeric*