### PR TITLE
feat: implement boundary-aware PDF slicing and tighten report template prose

### DIFF
--- a/components/report-template.tsx
+++ b/components/report-template.tsx
@@ -30,7 +30,7 @@ export const ReportTemplate: React.FC<ReportTemplateProps> = ({
   }
 
   const MarkdownComponents = {
-    p: ({ children }: { children: React.ReactNode }) => {
+    p: ({ children }: { children?: React.ReactNode }) => {
       if (!children || (typeof children === 'string' && !children.trim())) {
         return null
       }

--- a/components/report-template.tsx
+++ b/components/report-template.tsx
@@ -23,6 +23,24 @@ export const ReportTemplate: React.FC<ReportTemplateProps> = ({
   chatTitle,
   aiSummary
 }) => {
+  const normalizeMarkdown = (content: string): string => {
+    return content
+      .replace(/\n{3,}/g, '\n\n') // Collapse 3+ newlines to 2
+      .trim()
+  }
+
+  const MarkdownComponents = {
+    p: ({ children }: { children: React.ReactNode }) => {
+      if (!children || (typeof children === 'string' && !children.trim())) {
+        return null
+      }
+      if (Array.isArray(children) && children.every(child => typeof child === 'string' && !child.trim())) {
+        return null
+      }
+      return <p>{children}</p>
+    }
+  }
+
   const renderMessageContent = (content: any): string => {
     if (typeof content === 'string') {
       return content
@@ -113,9 +131,9 @@ export const ReportTemplate: React.FC<ReportTemplateProps> = ({
               <h2 className="text-2xl font-black text-[#003366] uppercase tracking-tight">Intelligence Executive Summary</h2>
             </div>
             <div className="bg-slate-50 p-10 rounded-2xl border-l-8 border-[#003366] shadow-inner">
-              <div className="prose prose-slate prose-lg max-w-none text-slate-800 font-medium leading-relaxed">
-                <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                  {aiSummary}
+              <div className="prose prose-slate prose-lg prose-p:my-1 max-w-none text-slate-800 font-medium leading-relaxed">
+                <ReactMarkdown remarkPlugins={[remarkGfm]} components={MarkdownComponents}>
+                  {normalizeMarkdown(aiSummary)}
                 </ReactMarkdown>
               </div>
             </div>
@@ -128,7 +146,7 @@ export const ReportTemplate: React.FC<ReportTemplateProps> = ({
               <span className="text-4xl font-black text-slate-200">01</span>
               <h2 className="text-2xl font-black text-[#003366] uppercase tracking-tight">Executive Visualization</h2>
             </div>
-            <div className="border-[12px] border-slate-50 rounded-2xl overflow-hidden shadow-2xl">
+            <div data-pdf-nosplit className="border-[12px] border-slate-50 rounded-2xl overflow-hidden shadow-2xl">
               <img src={mapSnapshot} alt="Map Snapshot" className="w-full h-auto block" crossOrigin="anonymous" />
               <div className="bg-slate-50 px-6 py-4 text-xs text-slate-500 text-center font-bold tracking-wide border-t border-slate-100">
                 ORBITAL PERSPECTIVE REF: {Math.random().toString(16).substring(2, 10).toUpperCase()}
@@ -167,14 +185,14 @@ export const ReportTemplate: React.FC<ReportTemplateProps> = ({
                 )
               } else if (message.type === 'response') {
                 return (
-                  <div key={index} className="prose prose-slate prose-lg max-w-none break-inside-avoid">
+                  <div key={index} className="prose prose-slate prose-lg prose-p:my-1 max-w-none break-inside-avoid">
                     <div className="flex items-center gap-3 mb-6">
                       <div className="w-1.5 h-6 bg-emerald-500"></div>
                       <p className="text-xs font-black text-emerald-700 uppercase tracking-[0.2em] m-0">Strategic Output</p>
                     </div>
                     <div className="text-slate-700 leading-relaxed font-medium">
-                      <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                        {contentString}
+                      <ReactMarkdown remarkPlugins={[remarkGfm]} components={MarkdownComponents}>
+                        {normalizeMarkdown(contentString)}
                       </ReactMarkdown>
                     </div>
                   </div>
@@ -190,12 +208,14 @@ export const ReportTemplate: React.FC<ReportTemplateProps> = ({
                       </div>
                       {result.summary && (
                         <div className="text-slate-800 text-lg font-bold leading-snug bg-white p-8 rounded-2xl border border-slate-100 shadow-sm">
-                          {result.summary}
+                          <ReactMarkdown remarkPlugins={[remarkGfm]} components={MarkdownComponents}>
+                            {normalizeMarkdown(result.summary)}
+                          </ReactMarkdown>
                         </div>
                       )}
                       <div className="flex flex-col items-center gap-12">
                         {result.mapboxImage && (
-                          <div className="space-y-4 w-full max-w-2xl">
+                          <div data-pdf-nosplit className="space-y-4 w-full max-w-2xl">
                             <div className="flex items-center justify-center gap-2">
                               <div className="w-2 h-2 rounded-full bg-indigo-500"></div>
                               <p className="text-[10px] text-slate-400 font-black uppercase tracking-widest">Spectral RGB Analysis View</p>
@@ -204,7 +224,7 @@ export const ReportTemplate: React.FC<ReportTemplateProps> = ({
                           </div>
                         )}
                         {result.googleImage && (
-                          <div className="space-y-4 w-full max-w-2xl">
+                          <div data-pdf-nosplit className="space-y-4 w-full max-w-2xl">
                             <div className="flex items-center justify-center gap-2">
                               <div className="w-2 h-2 rounded-full bg-orange-500"></div>
                               <p className="text-[10px] text-slate-400 font-black uppercase tracking-widest">High-Resolution Panchromatic Satellite</p>

--- a/lib/utils/report-generator.ts
+++ b/lib/utils/report-generator.ts
@@ -1,8 +1,8 @@
 export const generatePDFReport = async (elementId: string, fileName: string) => {
   const element = document.getElementById(elementId)
   if (!element) {
-    console.error(`Element with id ${elementId} not found in the DOM. Full document structure:`, document.body.innerHTML.substring(0, 500))
-    throw new Error(`Element with id ${elementId} not found. Please try again.`)
+    console.error(`Element with id ${elementId} not found in the DOM.`)
+    throw new Error(`Element with id ${elementId} not found.`)
   }
 
   try {
@@ -12,17 +12,15 @@ export const generatePDFReport = async (elementId: string, fileName: string) => 
     ])
 
     const images = Array.from(element.getElementsByTagName('img'))
-    const imageLoadTimeout = 10000 // 10 seconds timeout for high-res images
+    const imageLoadTimeout = 10000
 
-    // Wait for images to load, but don't block forever
     await Promise.race([
       Promise.all(
         images.map(img => {
           if (img.complete) return Promise.resolve()
           return new Promise((resolve) => {
             img.onload = resolve
-            img.onerror = resolve // Continue even if one image fails
-            // Force a check after a small delay for data URLs
+            img.onerror = resolve
             if (img.src.startsWith('data:')) setTimeout(resolve, 500)
           })
         })
@@ -30,29 +28,15 @@ export const generatePDFReport = async (elementId: string, fileName: string) => 
       new Promise(resolve => setTimeout(resolve, imageLoadTimeout))
     ])
 
-    const canvas = await html2canvas(element, {
-      scale: 3, // Increased scale for ultra-sharp text and images
-      useCORS: true,
-      logging: false,
-      allowTaint: true,
-      backgroundColor: '#ffffff',
-      imageTimeout: 15000,
-      onclone: (clonedDoc) => {
-        // Ensure the cloned element is visible for html2canvas
-        const clonedElement = clonedDoc.getElementById(elementId)
-        if (clonedElement) {
-          clonedElement.style.position = 'static'
-          clonedElement.style.left = '0'
-          clonedElement.style.visibility = 'visible'
-          clonedElement.style.width = '800px' // Fix width for consistent scaling
-        }
-      }
-    })
+    const templateWidth = 800 // The width we force for PDF generation
 
-    const imgData = canvas.toDataURL('image/png') // Use PNG for lossless quality and sharper text
+    // To get accurate positions for the 800px width used in the PDF,
+    // we temporarily set the element width.
+    const originalStyle = element.getAttribute('style') || ''
+    element.style.width = `${templateWidth}px`
+    element.style.position = 'relative'
 
-    // A4 dimensions in px at 72 DPI are roughly 595 x 842
-    // But we use the internal pageSize values for flexibility
+    const templateRect = element.getBoundingClientRect()
     const pdf = new jsPDF({
       orientation: 'portrait',
       unit: 'px',
@@ -61,24 +45,72 @@ export const generatePDFReport = async (elementId: string, fileName: string) => 
 
     const pdfWidth = pdf.internal.pageSize.getWidth()
     const pdfHeight = pdf.internal.pageSize.getHeight()
+    const pdfScale = pdfWidth / templateWidth
 
+    const protectedRanges = Array.from(element.querySelectorAll('[data-pdf-nosplit]'))
+      .map(el => {
+        const rect = el.getBoundingClientRect()
+        return {
+          top: (rect.top - templateRect.top) * pdfScale,
+          bottom: (rect.bottom - templateRect.top) * pdfScale
+        }
+      })
+      .sort((a, b) => a.top - b.top)
+
+    // Restore original style
+    element.setAttribute('style', originalStyle)
+
+    const canvas = await html2canvas(element, {
+      scale: 3,
+      useCORS: true,
+      logging: false,
+      allowTaint: true,
+      backgroundColor: '#ffffff',
+      imageTimeout: 15000,
+      onclone: (clonedDoc) => {
+        const clonedElement = clonedDoc.getElementById(elementId)
+        if (clonedElement) {
+          clonedElement.style.position = 'static'
+          clonedElement.style.left = '0'
+          clonedElement.style.visibility = 'visible'
+          clonedElement.style.width = `${templateWidth}px`
+        }
+      }
+    })
+
+    const imgData = canvas.toDataURL('image/png')
     const imgProps = pdf.getImageProperties(imgData)
-    const ratio = imgProps.height / imgProps.width
-    const scaledHeight = pdfWidth * ratio
+    const scaledHeight = pdfWidth * (imgProps.height / imgProps.width)
 
-    let heightLeft = scaledHeight
-    let position = 0
+    let currentPosition = 0
 
-    // Add first page
-    pdf.addImage(imgData, 'PNG', 0, position, pdfWidth, scaledHeight, undefined, 'FAST')
-    heightLeft -= pdfHeight
+    while (currentPosition < scaledHeight - 0.5) {
+      if (currentPosition > 0) {
+        pdf.addPage()
+      }
 
-    // Add subsequent pages if content overflows
-    while (heightLeft > 0) {
-      position = heightLeft - scaledHeight
-      pdf.addPage()
-      pdf.addImage(imgData, 'PNG', 0, position, pdfWidth, scaledHeight, undefined, 'FAST')
-      heightLeft -= pdfHeight
+      let nextPossibleCut = currentPosition + pdfHeight
+      let effectiveCut = nextPossibleCut
+
+      if (nextPossibleCut < scaledHeight) {
+        const straddle = protectedRanges.find(range =>
+          nextPossibleCut > range.top && nextPossibleCut < range.bottom
+        )
+
+        // Only move the cut if the element starts after our current position (with small buffer)
+        // and fits on a single page.
+        if (straddle && straddle.top > currentPosition + 10) {
+          const elementHeight = straddle.bottom - straddle.top
+          if (elementHeight <= pdfHeight) {
+            effectiveCut = straddle.top
+          }
+        }
+      } else {
+        effectiveCut = scaledHeight
+      }
+
+      pdf.addImage(imgData, 'PNG', 0, -currentPosition, pdfWidth, scaledHeight, undefined, 'FAST')
+      currentPosition = effectiveCut
     }
 
     pdf.save(`${fileName.replace(/[^a-z0-9]/gi, '_').toLowerCase()}_report.pdf`)


### PR DESCRIPTION
- Add data-pdf-nosplit markers to key images in Section 01 and 02 of the report template.
- Implement a boundary-aware slicing loop in generatePDFReport that prevents splitting protected elements across pages.
- Normalize Markdown content by collapsing redundant newlines and trimming whitespace.
- Implement a custom p renderer for ReactMarkdown to skip empty paragraphs.
- Tighten paragraph spacing with prose-p:my-1 Tailwind utilities.

---
*PR created automatically by Jules for task [17795820845734913689](https://jules.google.com/task/17795820845734913689) started by @ngoiyaeric*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved markdown rendering in reports by removing extra blank lines and skipping empty paragraphs.
  * Reduced awkward spacing in report sections for cleaner, more readable output.
  * Updated PDF generation to keep important images and content from being split across pages when possible.
  * Simplified error handling when a report cannot be generated due to missing page content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->