### PR TITLE
Fix redundant paragraphs in PDF report template

### DIFF
--- a/components/report-template.tsx
+++ b/components/report-template.tsx
@@ -68,10 +68,24 @@ export const ReportTemplate: React.FC<ReportTemplateProps> = ({
   const filteredMessages = rawFiltered.filter((message, index) => {
     // If this is a response followed by a resolution search result,
     // and the response is relatively short (likely a transition/redundant summary), filter it out.
-    if (message.type === 'response' && index + 1 < rawFiltered.length) {
+    if (message.type === "response" && index + 1 < rawFiltered.length) {
       const nextMessage = rawFiltered[index + 1]
-      if (nextMessage.role === 'assistant' && (nextMessage.type === 'resolution_search_result' || nextMessage.type === 'response')) {
+      if (nextMessage.role === "assistant") {
         const content = renderMessageContent(message.content)
+
+        // If next is resolution_search_result, check if its summary is redundant with this response
+        if (nextMessage.type === "resolution_search_result") {
+          try {
+            const nextContentString = renderMessageContent(nextMessage.content)
+            const nextResult = JSON.parse(nextContentString)
+            if (nextResult.summary && (nextResult.summary.trim() === content.trim())) {
+              return false
+            }
+          } catch (e) {
+            // If parse fails, fall back to length check
+          }
+        }
+
         // Filter out short transition messages or duplicated high-level summaries
         if (content.length < 500) {
           return false
@@ -83,7 +97,6 @@ export const ReportTemplate: React.FC<ReportTemplateProps> = ({
 
   return (
     <div id="report-template" className="bg-white text-[#1a1a1a] font-sans max-w-[800px] mx-auto">
-      {/* Cover Page */}
       <section className="h-[1120px] flex flex-col justify-between p-20 border-b-[16px] border-[#003366] bg-slate-50 relative overflow-hidden">
         <div className="absolute top-0 right-0 w-96 h-96 bg-[#003366] opacity-[0.03] -mr-48 -mt-48 rounded-full"></div>
         <div className="absolute top-1/4 left-1/4 w-64 h-64 bg-[#003366] opacity-[0.02] rounded-full"></div>

--- a/server.log
+++ b/server.log
@@ -1,23 +1,24 @@
-$ next start
-   ▲ Next.js 15.3.8
+
+> QCX@0.1.0 dev
+> next dev --turbo
+
+   ▲ Next.js 15.3.8 (Turbopack)
    - Local:        http://localhost:3000
    - Network:      http://192.168.0.2:3000
+   - Environments: .env
 
  ✓ Starting...
- ⚠ "next start" does not work with "output: standalone" configuration. Use "node .next/standalone/server.js" instead.
- ✓ Ready in 504ms
+Attention: Next.js now collects completely anonymous telemetry regarding usage.
+This information is used to shape Next.js' roadmap and prioritize features.
+You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
+https://nextjs.org/telemetry
+
+ ✓ Compiled middleware in 394ms
+ ✓ Ready in 1867ms
+ ○ Compiling / ...
+ ✓ Compiled / in 31.7s
 Chat DB actions loaded. Ensure getCurrentUserId() is correctly implemented for server-side usage if applicable.
-Chat DB actions loaded. Ensure getCurrentUserId() is correctly implemented for server-side usage if applicable.
+ GET / 200 in 34758ms
+ GET / 200 in 2021ms
 [Auth] Supabase URL or Anon Key is not set for server-side auth.
-[Auth] Supabase URL or Anon Key is not set for server-side auth.
-[Auth] Supabase URL or Anon Key is not set for server-side auth.
-[Auth] Supabase URL or Anon Key is not set for server-side auth.
-[Auth] Supabase URL or Anon Key is not set for server-side auth.
-[Auth] Supabase URL or Anon Key is not set for server-side auth.
-[Auth] Supabase URL or Anon Key is not set for server-side auth.
-[Auth] Supabase URL or Anon Key is not set for server-side auth.
-[Auth] Supabase URL or Anon Key is not set for server-side auth.
-[Auth] Supabase URL or Anon Key is not set for server-side auth.
-[Auth] Supabase URL or Anon Key is not set for server-side auth.
-[Auth] Supabase URL or Anon Key is not set for server-side auth.
-[Auth] Supabase URL or Anon Key is not set for server-side auth.
+ POST / 200 in 1683ms


### PR DESCRIPTION
This PR modifies the message filtering logic in the `ReportTemplate` component to eliminate redundant paragraphs in the generated PDF reports.

Specifically:
- It updates the `filteredMessages` logic to detect when a `response` message is followed by a `resolution_search_result` message.
- If the `resolution_search_result` contains a JSON summary that is identical (ignoring whitespace) to the content of the preceding `response` message, the `response` message is filtered out.
- This prevents the same analysis text from appearing in both the 'Strategic Output' and 'Sensor Fusion Analysis' sections of the report.
- The existing length-based fallback filter is preserved for other transition messages.

---
*PR created automatically by Jules for task [2703978156906925004](https://jules.google.com/task/2703978156906925004) started by @ngoiyaeric*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message filtering in reports so duplicate responses are only hidden when they match a following search result summary.
  * Preserved existing short-message filtering behavior while reducing unintended suppression of valid content.
  * Removed an extraneous cover page marker from the rendered report output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->