### PR TITLE
fix: redirect all user_id FKs from auth.users to public.users for Clerk auth support

### DIFF
--- a/drizzle/migrations/0002_fix_chat_db_normalization.sql
+++ b/drizzle/migrations/0002_fix_chat_db_normalization.sql
@@ -1,0 +1,60 @@
+-- Migration: fix_chat_db_normalization
+-- Description: Redirect all user_id foreign keys from auth.users to public.users
+-- to support Clerk-authenticated users who exist only in public.users.
+-- This normalizes the schema so public.users is the canonical identity table.
+-- Root cause: Clerk users authenticate via Clerk (not Supabase Auth), so their
+-- user IDs exist in public.users but NOT in auth.users. The FK constraint
+-- chats_user_id_fkey pointed to auth.users.id, causing foreign key violations
+-- when inserting chats for Clerk-authenticated users.
+
+-- Step 1: Drop all affected foreign key constraints referencing auth.users
+ALTER TABLE public.chats
+  DROP CONSTRAINT IF EXISTS chats_user_id_fkey;
+
+ALTER TABLE public.messages
+  DROP CONSTRAINT IF EXISTS messages_user_id_fkey;
+
+ALTER TABLE public.system_prompts
+  DROP CONSTRAINT IF EXISTS system_prompts_user_id_fkey;
+
+ALTER TABLE public.locations
+  DROP CONSTRAINT IF EXISTS locations_user_id_fkey;
+
+ALTER TABLE public.visualizations
+  DROP CONSTRAINT IF EXISTS visualizations_user_id_fkey;
+
+ALTER TABLE public.chat_participants
+  DROP CONSTRAINT IF EXISTS chat_participants_user_id_fkey;
+
+-- Step 2: Add new foreign key constraints referencing public.users.id
+ALTER TABLE public.chats
+  ADD CONSTRAINT chats_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+ALTER TABLE public.messages
+  ADD CONSTRAINT messages_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+ALTER TABLE public.system_prompts
+  ADD CONSTRAINT system_prompts_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+ALTER TABLE public.locations
+  ADD CONSTRAINT locations_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+ALTER TABLE public.visualizations
+  ADD CONSTRAINT visualizations_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+ALTER TABLE public.chat_participants
+  ADD CONSTRAINT chat_participants_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+-- Step 3: Add indexes on user_id columns for query performance
+CREATE INDEX IF NOT EXISTS idx_chats_user_id ON public.chats(user_id);
+CREATE INDEX IF NOT EXISTS idx_messages_user_id ON public.messages(user_id);
+CREATE INDEX IF NOT EXISTS idx_system_prompts_user_id ON public.system_prompts(user_id);
+CREATE INDEX IF NOT EXISTS idx_locations_user_id ON public.locations(user_id);
+CREATE INDEX IF NOT EXISTS idx_visualizations_user_id ON public.visualizations(user_id);
+CREATE INDEX IF NOT EXISTS idx_chat_participants_user_id ON public.chat_participants(user_id);


### PR DESCRIPTION
## Problem

Chat history save was failing for Clerk-authenticated users with the error:

```
insert or update on table "chats" violates foreign key constraint "chats_user_id_fkey"
Key (user_id)=(957edcef-6fbb-499b-bf14-2b5c9d3bdc9d) is not present in table "users".
```

## Root Cause

All `user_id` foreign key constraints on the chat-related tables referenced `auth.users.id`, but Clerk-authenticated users only exist in `public.users` (not in `auth.users`). The `auth.users` table is managed by Supabase Auth, while Clerk users are synced to `public.users` via the `sync_clerk_user()` function and the `on_auth_user_created` trigger.

Affected constraints:
- `chats_user_id_fkey` — was pointing to `auth.users.id`
- `messages_user_id_fkey` — was pointing to `auth.users.id`
- `system_prompts_user_id_fkey` — was pointing to `auth.users.id`
- `locations_user_id_fkey` — was pointing to `auth.users.id`
- `visualizations_user_id_fkey` — was pointing to `auth.users.id`
- `chat_participants_user_id_fkey` — was pointing to `auth.users.id`

Note: `calendar_notes_user_id_fkey` was already correctly pointing to `public.users.id`.

## Fix

All 6 FK constraints have been redirected to reference `public.users.id` as the canonical identity table. This normalizes the schema so that `public.users` serves as the unified identity store for both Clerk and Supabase Auth users.

Additionally, performance indexes have been added on all `user_id` columns.

## Database Change

The Supabase migration has already been applied directly to the production database via the Supabase MCP tool. This PR includes the migration file for schema tracking and drizzle-kit consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data consistency for chat-related records by aligning user references with the app’s primary user records.
  * Added safeguards so related chat data is removed automatically when a user is deleted.
  * Improved lookup performance on user-linked records for chats, messages, prompts, locations, visualizations, and participants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->