### PR TITLE
fix: deduplicate message IDs in saveChat to prevent ON CONFLICT error

### DIFF
--- a/lib/actions/chat-db.ts
+++ b/lib/actions/chat-db.ts
@@ -112,13 +112,30 @@ export async function saveChat(chatData: NewChat, messagesData: Omit<NewMessage,
       throw new Error('Failed to establish chatId for chat operation.');
     }
 
-    // Save messages
+    // Save messages — deduplicate by ID first, then generate unique IDs for any remaining duplicates
+    // This prevents "ON CONFLICT DO UPDATE cannot affect row a second time" when the AI state
+    // contains multiple messages sharing the same ID (e.g., groupeId used for response + related + followup).
     if (messagesData && messagesData.length > 0) {
-      const messagesToInsert = messagesData.map(msg => ({
-        ...msg,
-        chatId: chatId!, // Ensure chatId is set for all messages
-        userId: msg.userId || chatData.userId!, // Ensure userId is set
-      }));
+      const seenIds = new Set<string>();
+      const messagesToInsert: typeof messages.$inferInsert[] = [];
+
+      for (const msg of messagesData) {
+        let id = msg.id;
+
+        // If we've already seen this ID in this batch, generate a unique one
+        while (seenIds.has(id)) {
+          id = `${id}-${Math.random().toString(36).substring(2, 8)}`;
+        }
+        seenIds.add(id);
+
+        messagesToInsert.push({
+          ...msg,
+          id,
+          chatId: chatId!,
+          userId: msg.userId || chatData.userId!,
+        });
+      }
+
       await tx.insert(messages).values(messagesToInsert).onConflictDoUpdate({ target: messages.id, set: { content: sql`EXCLUDED.content`, role: sql`EXCLUDED.role` } });
     }
     return chatId;


### PR DESCRIPTION
## Problem

When the AI state `submit` function builds messages, it uses a shared `groupeId` for multiple message types (response, resolution_search_result, related, followup), giving them all the same ID.

When `onSetAIState` calls `saveChat`, the batch insert hits:

```
ERROR: ON CONFLICT DO UPDATE command cannot affect row a second time (21000)
```

## Fix

Before inserting, `saveChat` now scans for duplicate IDs within the batch and appends a unique suffix to any duplicates, ensuring every row in the INSERT has a distinct primary key.

## Files Changed

- `lib/actions/chat-db.ts` — saveChat deduplication logic