### PR TITLE
UI: fix mobile profile accessibility, prompt overflow, desktop history icon, tablet spacing, and icon distribution

### DIFF
--- a/FIXES_SUMMARY.md
+++ b/FIXES_SUMMARY.md
@@ -1,0 +1,21 @@
+# UI Fixes Summary
+
+## Issue 1: Profile icon not usable on mobile
+**Root cause:** In `profile-toggle.tsx` line 68-74, when `isMobile` is true, the ProfileToggle renders a disabled Button.
+**Fix:** Remove the `disabled` attribute so the profile icon is clickable on mobile. The existing ProfileToggle already renders properly in the mobile-icons-bar.
+
+## Issue 2: Example prompts overflow past the screen on mobile
+**Root cause:** In `empty-screen.tsx`, the prompt buttons don't have `whitespace-normal` or `overflow-wrap: break-word`, so long text extends past the screen edge on mobile.
+**Fix:** Add `whitespace-normal text-left break-words max-w-full` to the EmptyScreen buttons and ensure the container has proper overflow handling.
+
+## Issue 3: History icon missing from desktop layout
+**Root cause:** In `history-container.tsx`, the class `sm:hidden` hides the history icon on all screens above 640px (tablet and desktop).
+**Fix:** Remove `sm:hidden` so the history icon is visible on all screen sizes including desktop.
+
+## Issue 4: Tablet layout example prompts positioned too low
+**Root cause:** In `chat.tsx` desktop layout, the chat section has `pt-16 md:pt-20` padding top which pushes content too far down on tablet (md breakpoint at 768px). Also the sidebar uses `hidden md:flex` in header which only shows at md, and the desktop layout uses `flex justify-start` which may not be optimal for tablet.
+**Fix:** Adjust the padding and spacing in the desktop/tablet layout. The chat panel container has excessive padding. Also need to check if the prompt area positioning in the empty screen needs adjustment for tablet.
+
+## Issue 5: Icons not equally spread across the screen
+**Root cause:** In `globals.css`, the `.mobile-icons-bar-content` uses `justify-content: space-between` for tablet (768px+) but the `gap: 0` removes spacing between items. The icons are not evenly distributed.
+**Fix:** Use `justify-content: space-evenly` instead of `space-between` for tablet, and add a small gap for better visual spacing.

--- a/app/globals.css
+++ b/app/globals.css
@@ -159,8 +159,8 @@
     .mobile-icons-bar-content {
       min-width: 0;
       width: 100%;
-      justify-content: space-between;
-      gap: 0; /* Remove gap if using space-between */
+      justify-content: space-evenly;
+      gap: 8px;
     }
   }
 

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -187,19 +187,21 @@ export function Chat({ id }: ChatProps) {
   return (
     <MapDataProvider> {/* Add Provider */}
       <HeaderSearchButton />
-      <div className="flex justify-start items-start">
+      <div className="flex justify-start items-start w-full">
         {/* This is the new div for scrolling */}
-        <div className="w-1/2 flex flex-col space-y-3 md:space-y-4 px-8 sm:px-12 pt-16 md:pt-20 pb-4 h-[calc(100vh-0.5in)] overflow-y-auto">
+        <div className="w-1/2 flex flex-col space-y-3 md:space-y-4 px-4 sm:px-8 lg:px-12 pt-8 sm:pt-12 md:pt-16 pb-4 h-[calc(100vh-0.5in)] overflow-y-auto">
         {isCalendarOpen ? (
           <CalendarNotepad chatId={id} />
         ) : (
           <>
-            <ChatPanel 
-              messages={messages} 
-              input={input} 
-              setInput={setInput} 
-              onSuggestionsChange={setSuggestions}
-            />
+            <div className="space-y-2 md:space-y-4">
+              <ChatPanel 
+                messages={messages} 
+                input={input} 
+                setInput={setInput} 
+                onSuggestionsChange={setSuggestions}
+              />
+            </div>
             <div className="relative min-h-[100px]">
               <div className={cn("transition-all duration-300", suggestions ? "blur-md pointer-events-none" : "")}>
                 {showEmptyScreen ? (

--- a/components/empty-screen.tsx
+++ b/components/empty-screen.tsx
@@ -32,23 +32,23 @@ export function EmptyScreen({
   className?: string;
 }) {
   return (
-    <div className={`mx-auto w-full transition-all ${className}`}>
+    <div className={`mx-auto w-full transition-all overflow-hidden ${className}`}>
       <div className="bg-background p-2">
-        <div className="mt-4 flex flex-col items-start space-y-2 mb-4">
+        <div className="mt-0 sm:mt-4 flex flex-col items-start space-y-2 mb-4">
           {exampleMessages.map((item) => {
             const Icon = item.icon;
             return (
               <Button
                 key={item.message} // Use a unique property as the key.
                 variant="link"
-                className="h-auto p-0 text-base flex items-center"
+                className="h-auto p-0 text-base flex items-center gap-1.5 whitespace-normal text-left break-words max-w-[calc(100vw-2rem)] sm:max-w-full"
                 name={item.message}
                 onClick={async () => {
                   submitMessage(item.message);
                 }}
               >
-                <Icon size={16} className="mr-2 text-muted-foreground" />
-                {item.heading}
+                <Icon size={16} className="mr-2 text-muted-foreground flex-shrink-0" />
+                <span className="truncate sm:truncate-none">{item.heading}</span>
               </Button>
             );
           })}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -66,7 +66,7 @@ export const Header = () => {
         </h1>
       </div>
       
-      <div className="flex-1 hidden md:flex justify-center gap-10 items-center z-10">
+      <div className="flex-1 hidden md:flex justify-evenly items-center z-10 px-4">
         <ProfileToggle/>
         
         <MapToggle />

--- a/components/history-container.tsx
+++ b/components/history-container.tsx
@@ -7,7 +7,7 @@ type HistoryContainerProps = {
 
 const HistoryContainer: React.FC<HistoryContainerProps> = ({ location }) => {
   return (
-    <div className="sm:hidden block">
+    <div className="block">
       <History location={location} />
     </div>
   )

--- a/components/history.tsx
+++ b/components/history.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { Button } from '@/components/ui/button'
-import { ChevronLeft, Menu } from 'lucide-react'
+import { ChevronLeft, History as HistoryIcon } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { useHistoryToggle } from './history-toggle-context'
 
@@ -20,7 +20,7 @@ export function History({ location }: HistoryProps) {
       data-testid="history-button"
       onClick={toggleHistory}
     >
-      {location === 'header' ? <Menu /> : <ChevronLeft size={16} />}
+      {location === 'header' ? <HistoryIcon size={20} /> : <ChevronLeft size={16} />}
     </Button>
   )
 }

--- a/components/profile-toggle.tsx
+++ b/components/profile-toggle.tsx
@@ -67,7 +67,7 @@ export function ProfileToggle() {
 
   if (isMobile) {
     return (
-      <Button variant="ghost" size="icon" className="relative" data-testid="profile-toggle" disabled>
+      <Button variant="ghost" size="icon" className="relative" data-testid="profile-toggle" onClick={() => handleSectionToggle(ProfileToggleEnum.Account)}>
         <ProfileIcon />
         <span className="sr-only">Open profile menu</span>
       </Button>


### PR DESCRIPTION
## Summary

This PR addresses five UI issues identified in the application across mobile, tablet, and desktop layouts:

### 1. Mobile Profile Icon Not Usable
**File:** `components/profile-toggle.tsx`

The profile icon was rendered as a disabled button on mobile devices, making it completely unclickable. Removed the `disabled` attribute and added an `onClick` handler that toggles the profile section view, making the profile icon fully functional on mobile.

### 2. Example Prompts Overflow Past Screen Edge
**File:** `components/empty-screen.tsx`

Example prompts (e.g., "How does climate change affect our experience?") were extending past the screen width on mobile due to missing text-wrapping and overflow constraints. Added `whitespace-normal`, `break-words`, and responsive max-width constraints. The icon now uses `flex-shrink-0` to prevent squishing, and the text is wrapped in a span with responsive truncation.

### 3. Chat History Icon Missing from Desktop
**File:** `components/history-container.tsx`, `components/history.tsx`

The history container was hidden on all screens wider than 640px due to the `sm:hidden` class. Removed this class so the chat history icon is visible in the top bar on all screen sizes including desktop. Also updated the header icon from `Menu` (hamburger) to `History` for better semantic clarity.

### 4. Tablet Layout — Example Prompts Positioned Too Low
**File:** `components/chat.tsx`

The desktop/tablet chat section had excessive top padding (`pt-16 md:pt-20`) that pushed prompts too far down on tablet screens. Adjusted to responsive padding: `pt-8` on mobile, `sm:pt-12` on small tablet, and `md:pt-16` on larger screens. Also reduced horizontal padding on smaller screens and added proper gap spacing between the chat panel and empty screen.

### 5. Icons Not Equally Spread Across Screen
**Files:** `components/header.tsx`, `app/globals.css`

- **Desktop header:** Changed from fixed `gap-10` to `justify-evenly` with `px-4` padding so icons distribute evenly across the available space regardless of screen width.
- **Mobile/tablet icons bar:** Changed tablet override from `justify-content: space-between` to `justify-content: space-evenly` with an 8px gap for consistent, equal spacing between all icons.

## Files Changed

| File | Changes |
|------|---------|
| `components/profile-toggle.tsx` | Removed disabled on mobile, added onClick handler |
| `components/empty-screen.tsx` | Added overflow prevention, word wrapping, responsive max-width |
| `components/history-container.tsx` | Removed sm:hidden to show history on all screen sizes |
| `components/history.tsx` | Changed header icon from Menu to History |
| `components/header.tsx` | Changed to justify-evenly for even icon distribution |
| `components/chat.tsx` | Adjusted responsive padding and spacing for tablet layout |
| `app/globals.css` | Changed mobile icons-bar to space-evenly with gap |