### PR TITLE
UI: improve SW update notification popup with cancel button, left position, and auto-dismiss

### DIFF
--- a/components/sw-update-notification.tsx
+++ b/components/sw-update-notification.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { toast } from 'sonner';
-import { Button } from '@/components/ui/button';
 
 export function SWUpdateNotification() {
-  useEffect(() => {
+  const [hasShown, setHasShown] = useState(false);
+
+  const showToast = useCallback(() => {
     if (
       typeof window !== 'undefined' &&
       'serviceWorker' in navigator &&
@@ -14,19 +15,30 @@ export function SWUpdateNotification() {
       const serwist = window.serwist;
 
       const onWaiting = () => {
-        toast.info('A new version is available!', {
-          description: 'Click reload to update to the latest version.',
-          duration: Infinity,
-          action: {
-            label: 'Reload',
-            onClick: () => {
-              serwist.addEventListener("controlling", () => {
-                window.location.reload();
-              });
-              serwist.messageSkipWaiting();
+        // Only show the toast once per session to avoid popping up too often
+        if (!hasShown) {
+          setHasShown(true);
+          toast.info('A new version is available!', {
+            description: 'Click reload to update to the latest version.',
+            duration: 15000, // Auto-dismiss after 15 seconds instead of staying forever
+            position: 'bottom-left', // Show on the left side instead of right
+            action: {
+              label: 'Reload',
+              onClick: () => {
+                serwist.addEventListener("controlling", () => {
+                  window.location.reload();
+                });
+                serwist.messageSkipWaiting();
+              },
             },
-          },
-        });
+            cancel: {
+              label: 'Cancel',
+              onClick: () => {
+                // User dismissed the notification
+              },
+            },
+          });
+        }
       };
 
       serwist.addEventListener("waiting", onWaiting);
@@ -35,7 +47,11 @@ export function SWUpdateNotification() {
         serwist.removeEventListener("waiting", onWaiting);
       };
     }
-  }, []);
+  }, [hasShown]);
+
+  useEffect(() => {
+    showToast();
+  }, [showToast]);
 
   return null;
 }


### PR DESCRIPTION
## Summary

This PR improves the service worker update notification popup in three ways:

### 1. Added Cancel Button
A **Cancel** button is now available alongside the existing **Reload** button, allowing users to dismiss the notification without being forced to reload the page.

### 2. Moved to Left Side
Changed the toast position from the default bottom-right to **`bottom-left`** so the popup appears on the left side of the screen.

### 3. Reduced Frequency
The notification was popping up too often due to two issues:
- **Auto-dismiss:** Changed `duration` from `Infinity` (permanent) to **15 seconds** so the toast auto-dismisses instead of staying on screen forever.
- **Once per session:** Added a `hasShown` state flag to ensure the popup only shows **once per session** instead of repeatedly appearing.

## File Changed

| File | Changes |
|------|---------|
| `components/sw-update-notification.tsx` | Added cancel button, changed position to bottom-left, added auto-dismiss after 15s, added once-per-session guard |