### PR TITLE
fix: use crypto.randomUUID() for deduplicated message IDs

### DIFF
--- a/lib/actions/chat-db.ts
+++ b/lib/actions/chat-db.ts
@@ -122,9 +122,9 @@ export async function saveChat(chatData: NewChat, messagesData: Omit<NewMessage,
       for (const msg of messagesData) {
         let id = msg.id ?? crypto.randomUUID();
 
-        // If we've already seen this ID in this batch, generate a unique one
+        // If we've already seen this ID in this batch, generate a new UUID
         while (seenIds.has(id)) {
-          id = `${id}-${Math.random().toString(36).substring(2, 8)}`;
+          id = crypto.randomUUID();
         }
         seenIds.add(id);
 


### PR DESCRIPTION
The `saveChat` function in `lib/actions/chat-db.ts` was appending a random suffix (e.g. `-mxb7wz`) to duplicate message IDs to avoid `ON CONFLICT` errors. Since `nanoid()` is actually `uuidv4()`, this produced invalid UUID strings like `4ccab2ce-...-103d5125687c-mxb7wz` which PostgreSQL rejected with:

```
[cause]: u: invalid input syntax for type uuid: "4ccab2ce-f948-4a7b-bec6-103d5125687c-mxb7wz"
code: '22P02'
```

**Root cause:** In `app/actions.tsx`, the `onSetAIState` handler assigns the same `groupeId` (generated by `nanoid() = uuidv4()`) to multiple assistant messages (`response`, `related`, `followup`, `resolution_search_result`). When `saveChat` encounters these duplicate IDs, the deduplication loop appended a string suffix, breaking the UUID format.

**Fix:** Replace the suffix append (`${id}-${Math.random()...}`) with `crypto.randomUUID()` so deduplicated IDs are always valid UUID v4 strings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of duplicate message identifiers during chat saves.
  * Conflicting identifiers are now replaced with newly generated unique identifiers, preventing collisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->