### PR TITLE
fix: chat persistence, retrieval, and clear history crash

### DIFF
--- a/app/actions.tsx
+++ b/app/actions.tsx
@@ -503,7 +503,11 @@ export const AI = createAI<AIState, UIState>({
   onSetAIState: async ({ state }) => {
     'use server'
 
-    if (!state.messages.some(e => e.type === 'response')) {
+    // Only save chats that have actual messages (skip empty chats)
+    // Previously, we only saved when there was a 'response' type message,
+    // which excluded definition-only chats and other special flows.
+    // Now we save any chat with messages, regardless of message type.
+    if (!state.messages || state.messages.length === 0) {
       return
     }
 

--- a/app/api/chats/all/route.ts
+++ b/app/api/chats/all/route.ts
@@ -2,36 +2,53 @@
 import { NextResponse } from 'next/server';
 import { clearHistory as dbClearHistory } from '@/lib/actions/chat-db';
 import { getCurrentUserIdOnServer } from '@/lib/auth/get-current-user';
-import { revalidatePath } from 'next/cache'; // For revalidating after clearing
+import { revalidatePath } from 'next/cache';
 
+/**
+ * Clears all chat history for the authenticated user.
+ * Includes retry logic for transient database connection errors
+ * that can occur on serverless platforms (Vercel cold starts,
+ * connection pool exhaustion).
+ */
 export async function DELETE() {
-  try {
-    const userId = await getCurrentUserIdOnServer();
-    if (!userId) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const MAX_RETRIES = 3;
+  const RETRY_DELAY_MS = 500;
+
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const userId = await getCurrentUserIdOnServer();
+      if (!userId) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      }
+
+      const success = await dbClearHistory(userId);
+      if (success) {
+        revalidatePath('/');
+        revalidatePath('/search', 'layout');
+        return NextResponse.json({ message: 'History cleared successfully' }, { status: 200 });
+      } else {
+        // If this is the last attempt, return a failure response
+        if (attempt === MAX_RETRIES) {
+          return NextResponse.json({ error: 'Failed to clear history after multiple attempts' }, { status: 500 });
+        }
+        console.warn(`clearHistory returned false (attempt ${attempt}/${MAX_RETRIES}), retrying...`);
+      }
+    } catch (error) {
+      console.error(`Error clearing history via API (attempt ${attempt}/${MAX_RETRIES}):`, error);
+      if (attempt === MAX_RETRIES) {
+        let errorMessage = 'Internal Server Error clearing history';
+        if (error instanceof Error) {
+          errorMessage = error.message;
+        }
+        return NextResponse.json({ error: errorMessage }, { status: 500 });
+      }
     }
 
-    const success = await dbClearHistory(userId);
-    if (success) {
-      revalidatePath('/'); // Revalidate home or relevant pages
-      revalidatePath('/search'); // Revalidate search path
-      return NextResponse.json({ message: 'History cleared successfully' }, { status: 200 });
-    } else {
-      // This case might be redundant if dbClearHistory throws an error on failure,
-      // but kept for explicitness if it returns false for "no error but nothing done".
-      return NextResponse.json({ error: 'Failed to clear history' }, { status: 500 });
+    // Wait before retrying
+    if (attempt < MAX_RETRIES) {
+      await new Promise(resolve => setTimeout(resolve, RETRY_DELAY_MS));
     }
-  } catch (error) {
-    console.error('Error clearing history via API:', error);
-    let errorMessage = 'Internal Server Error clearing history';
-    if (error instanceof Error && error.message) {
-        // Use the error message from dbClearHistory if available (e.g., "User ID is required")
-        // This depends on dbClearHistory actually throwing or returning specific error messages.
-        // The current dbClearHistory in chat.ts returns {error: ...} which won't be caught here as an Error instance directly.
-        // However, the dbClearHistory in chat-db.ts returns boolean.
-        // Let's assume if dbClearHistory from chat-db.ts (which returns boolean) fails, it's a generic 500.
-        // If it were to throw, that would be caught.
-    }
-    return NextResponse.json({ error: errorMessage }, { status: 500 });
   }
+
+  return NextResponse.json({ error: 'Failed to clear history' }, { status: 500 });
 }

--- a/app/search/[id]/page.tsx
+++ b/app/search/[id]/page.tsx
@@ -44,18 +44,25 @@ export default async function SearchPage({ params }: SearchPageProps) {
   // Fetch messages for the chat
   const dbMessages: DrizzleMessage[] = await getChatMessages(chat.id);
 
-  // Transform DrizzleMessages to AIMessages
+  // Transform DrizzleMessages to AIMessages — restore persisted type and name
   const initialMessages: AIMessage[] = dbMessages.map((dbMsg): AIMessage => {
+    const dbMsgWithMeta = dbMsg as DrizzleMessage & { messageType: string | null; messageName: string | null };
+    // Validate the messageType against the known AIMessage['type'] values
+    const validTypes: AIMessage['type'][] = [
+      'response', 'related', 'skip', 'inquiry', 'input',
+      'input_related', 'tool', 'followup', 'end', 'drawing_context',
+      'resolution_search_result', 'definition'
+    ];
+    const safeType = (dbMsgWithMeta.messageType && validTypes.includes(dbMsgWithMeta.messageType as AIMessage['type']))
+      ? (dbMsgWithMeta.messageType as AIMessage['type'])
+      : undefined;
     return {
       id: dbMsg.id,
-      role: dbMsg.role as AIMessage['role'], // Cast role, ensure AIMessage['role'] includes all dbMsg.role possibilities
+      role: dbMsg.role as AIMessage['role'],
       content: dbMsg.content,
+      type: safeType,
+      name: dbMsgWithMeta.messageName || undefined,
       createdAt: dbMsg.createdAt ? new Date(dbMsg.createdAt) : undefined,
-      // 'type' and 'name' are not in the basic Drizzle 'messages' schema.
-      // These would be undefined unless specific logic is added to derive them.
-      // For instance, if a message with role 'tool' should have a 'name',
-      // or if some messages have a specific 'type' based on content or other flags.
-      // This mapping assumes standard user/assistant messages primarily.
     };
   });
 

--- a/components/clear-history.tsx
+++ b/components/clear-history.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -14,6 +15,7 @@ import {
 } from '@/components/ui/alert-dialog'
 import { Button } from '@/components/ui/button'
 import { clearChats } from '@/lib/actions/chat'
+import { useHistoryToggle } from './history-toggle-context'
 import { toast } from 'sonner'
 import { Spinner } from './ui/spinner'
 
@@ -24,6 +26,8 @@ type ClearHistoryProps = {
 export function ClearHistory({ empty }: ClearHistoryProps) {
   const [open, setOpen] = useState(false)
   const [isPending, startTransition] = useTransition()
+  const router = useRouter()
+  const { setHistoryOpen } = useHistoryToggle()
   return (
     <AlertDialog open={open} onOpenChange={setOpen}>
       <AlertDialogTrigger asChild>
@@ -51,6 +55,13 @@ export function ClearHistory({ empty }: ClearHistoryProps) {
                   toast.error(result.error)
                 } else {
                   toast.success('History cleared')
+                  // Close the history sheet BEFORE redirecting to avoid a race condition
+                  setHistoryOpen(false)
+                  // Use router.replace instead of router.push to avoid a race between
+                  // navigation and refresh that can crash when the current page was deleted
+                  setTimeout(() => {
+                    router.replace('/')
+                  }, 100)
                 }
                 setOpen(false)
               })

--- a/components/sidebar/chat-history-client.tsx
+++ b/components/sidebar/chat-history-client.tsx
@@ -34,7 +34,7 @@ export function ChatHistoryClient({}: ChatHistoryClientProps) {
   const [isClearPending, startClearTransition] = useTransition();
   const [isAlertDialogOpen, setIsAlertDialogOpen] = useState(false);
   const [isCreditsVisible, setIsCreditsVisible] = useState(false);
-  const { isHistoryOpen } = useHistoryToggle();
+  const { isHistoryOpen, setHistoryOpen } = useHistoryToggle();
   const router = useRouter();
 
   useEffect(() => {
@@ -71,10 +71,7 @@ export function ChatHistoryClient({}: ChatHistoryClientProps) {
   const handleClearHistory = async () => {
     startClearTransition(async () => {
       try {
-        // We need a new API endpoint for clearing history
-        // Example: DELETE /api/chats (or POST /api/clear-history)
-        // This endpoint will call clearHistory(userId) from chat-db.ts
-        const response = await fetch('/api/chats/all', { // Placeholder for the actual clear endpoint
+        const response = await fetch('/api/chats/all', {
           method: 'DELETE',
         });
 
@@ -86,9 +83,15 @@ export function ChatHistoryClient({}: ChatHistoryClientProps) {
         toast.success('History cleared');
         setChats([]); // Clear chats from UI
         setIsAlertDialogOpen(false);
-        router.refresh(); // Refresh to reflect changes, potentially redirect if on a chat page
-        // Consider redirecting to '/' if current page is a chat that got deleted.
-        // The old clearChats action did redirect('/');
+        // Close the history sheet BEFORE redirecting to avoid a race condition
+        // where the sheet tries to re-fetch the deleted chat list.
+        setHistoryOpen(false);
+        // Use router.replace instead of router.push + router.refresh to avoid
+        // a race between navigation and refresh that can crash when the current
+        // page (/search/[id]) was just deleted.
+        setTimeout(() => {
+          router.replace('/');
+        }, 100);
       } catch (err) {
         if (err instanceof Error) {
           toast.error(err.message);

--- a/drizzle/migrations/0009_add_message_type_name.sql
+++ b/drizzle/migrations/0009_add_message_type_name.sql
@@ -1,0 +1,12 @@
+-- Migration 0009: Add messageType and messageName columns to messages table
+-- These columns store the AI message 'type' and 'name' fields, which are essential
+-- for rehydrating chat state from the database when navigating to /search/[id].
+-- The 'type' field determines how messages are rendered (response, input, related,
+-- followup, resolution_search_result, tool, definition, etc.) and without it,
+-- getUIStateFromAIState filters out all messages and the chat appears empty.
+-- The 'name' field stores tool names (e.g., 'search', 'retrieve', 'videoSearch')
+-- for tool-type messages.
+
+ALTER TABLE "messages" ADD COLUMN "message_type" text;
+--> statement-breakpoint
+ALTER TABLE "messages" ADD COLUMN "message_name" text;

--- a/lib/actions/chat-db.ts
+++ b/lib/actions/chat-db.ts
@@ -74,8 +74,6 @@ export async function getChatsPage(
 /**
  * Saves a chat and its messages. If the chat exists, it updates it.
  * This function should handle both creating new chats and appending messages.
- * The PR implies complex logic for saving, including message IDs.
- * This is a simplified version; PR #533 might have more granular message saving.
  * @param chatData - The chat data to save.
  * @param messagesData - An array of messages to save with the chat.
  * @returns The saved chat ID.
@@ -97,10 +95,14 @@ export async function saveChat(chatData: NewChat, messagesData: Omit<NewMessage,
         const newChatResult = await tx.insert(chats).values(chatData).returning({ id: chats.id });
         chatId = newChatResult[0].id;
       } else {
-        // Optionally update chat metadata here if needed, e.g., title
-        if (chatData.title) {
-          await tx.update(chats).set({ title: chatData.title, visibility: chatData.visibility, updatedAt: chatData.updatedAt }).where(eq(chats.id, chatId));
-        }
+        // Update chat metadata (title, visibility, path, updatedAt) on every save
+        // to ensure the chat record stays current with the latest state
+        await tx.update(chats).set({
+          title: chatData.title,
+          visibility: chatData.visibility,
+          path: chatData.path,
+          updatedAt: chatData.updatedAt,
+        }).where(eq(chats.id, chatId));
       }
     } else { // No chat ID, create new chat
       const newChatResult = await tx.insert(chats).values(chatData).returning({ id: chats.id });
@@ -108,7 +110,6 @@ export async function saveChat(chatData: NewChat, messagesData: Omit<NewMessage,
     }
 
     if (!chatId) {
-      // console.error('Failed to establish chatId within transaction.'); // Optional: for server logs
       throw new Error('Failed to establish chatId for chat operation.');
     }
 
@@ -136,7 +137,16 @@ export async function saveChat(chatData: NewChat, messagesData: Omit<NewMessage,
         });
       }
 
-      await tx.insert(messages).values(messagesToInsert).onConflictDoUpdate({ target: messages.id, set: { content: sql`EXCLUDED.content`, role: sql`EXCLUDED.role` } });
+      await tx.insert(messages).values(messagesToInsert).onConflictDoUpdate({
+        target: messages.id,
+        set: {
+          content: sql`EXCLUDED.content`,
+          role: sql`EXCLUDED.role`,
+          message_type: sql`EXCLUDED.message_type`,
+          message_name: sql`EXCLUDED.message_name`,
+          createdAt: sql`EXCLUDED.created_at`,
+        }
+      });
     }
     return chatId;
   });
@@ -145,8 +155,6 @@ export async function saveChat(chatData: NewChat, messagesData: Omit<NewMessage,
 
 /**
  * Creates a single message within a chat.
- * PR #533 has commits like "feat: Add message update and trailing deletion logic",
- * suggesting more granular message operations. This is a basic create.
  * @param messageData - The message data to save.
  * @returns The created message object or null if error.
  */
@@ -189,10 +197,15 @@ export async function deleteChat(id: string, userId: string): Promise<boolean> {
 
 /**
  * Clears the chat history for a given user (deletes all their chats).
+ * Includes retry logic for transient database connection errors
+ * that can occur on serverless platforms (Vercel cold starts,
+ * connection pool exhaustion).
  * @param userId - The ID of the user whose chat history to clear.
+ * @param retryCount - Internal retry counter (do not set manually).
  * @returns True if history was cleared, false otherwise.
  */
-export async function clearHistory(userId: string): Promise<boolean> {
+export async function clearHistory(userId: string, retryCount: number = 0): Promise<boolean> {
+  const MAX_RETRIES = 2;
   if (!userId) {
     console.error('clearHistory called without userId.');
     return false;
@@ -203,6 +216,12 @@ export async function clearHistory(userId: string): Promise<boolean> {
     return true;
   } catch (error) {
     console.error('Error clearing history:', error);
+    if (retryCount < MAX_RETRIES) {
+      console.warn(`Retrying clearHistory (${retryCount + 1}/${MAX_RETRIES})...`);
+      // Wait before retrying (exponential backoff)
+      await new Promise(resolve => setTimeout(resolve, 500 * Math.pow(2, retryCount)));
+      return clearHistory(userId, retryCount + 1);
+    }
     return false;
   }
 }
@@ -210,7 +229,7 @@ export async function clearHistory(userId: string): Promise<boolean> {
 /**
  * Retrieves all messages for a given chat ID, ordered by creation time.
  * @param chatId - The ID of the chat whose messages to retrieve.
- * @returns An array of message objects.
+ * @returns An array of message objects including messageType and messageName.
  */
 export async function getMessagesByChatId(chatId: string): Promise<Message[]> {
   if (!chatId) {
@@ -229,12 +248,3 @@ export async function getMessagesByChatId(chatId: string): Promise<Message[]> {
     return [];
   }
 }
-
-// More granular functions might be needed based on PR #533 specifics:
-// - updateMessage(messageId: string, updates: Partial<NewMessage>): Promise<Message | null>
-// - deleteMessage(messageId: string, userId: string): Promise<boolean>
-// - deleteTrailingMessages(chatId: string, lastKeptMessageId: string): Promise<void>
-// These are placeholders for now and can be implemented if subsequent steps show they are directly part of PR #533's changes.
-// The PR mentions "feat: Add message update and trailing deletion logic" and "refactor(chat): Adjust message edit logic".
-
-console.log('Chat DB actions loaded. Ensure getCurrentUserId() is correctly implemented for server-side usage if applicable.');

--- a/lib/actions/chat.ts
+++ b/lib/actions/chat.ts
@@ -185,7 +185,12 @@ export async function clearChats(
       return { error: 'Failed to clear chats from database.' }
     }
     revalidatePath('/')
-    redirect('/')
+    revalidatePath('/search', 'layout')
+    // Do NOT redirect here — let the client handle navigation.
+    // redirect('/') in a server action called from a client transition
+    // can cause crashes when the current page is a deleted chat (/search/[id]).
+    // The client components (clear-history.tsx and chat-history-client.tsx)
+    // will handle redirecting to '/' after success.
   } catch (error) {
     console.error('Error clearing chats from DB:', error)
     return { error: 'Failed to clear chat history' }
@@ -213,6 +218,8 @@ export async function saveChat(chat: OldChatType, userId: string): Promise<strin
     userId: effectiveUserId,
     role: msg.role,
     content: typeof msg.content === 'object' ? JSON.stringify(msg.content) : msg.content,
+    messageType: msg.type || null,
+    messageName: msg.name || null,
     createdAt: msg.createdAt ? new Date(msg.createdAt) : new Date(),
   }));
 

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -64,6 +64,8 @@ export const messages = pgTable('messages', {
   userId: uuid('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
   role: text('role').notNull(),
   content: text('content').notNull(),
+  messageType: text('message_type'), // Stores the AI message 'type' field (response, input, related, followup, etc.)
+  messageName: text('message_name'), // Stores the AI message 'name' field (tool name, etc.)
   embedding: vector('embedding'),
   locationId: uuid('location_id').references(() => locations.id, { onDelete: 'set null' }),
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),

--- a/tests/chat-persistence.spec.ts
+++ b/tests/chat-persistence.spec.ts
@@ -1,0 +1,260 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Chat Persistence and Retrieval', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector('[data-testid="chat-input"]');
+  });
+
+  test('should save a chat and retrieve it after navigating to a new chat', async ({ page }) => {
+    // Send a message
+    await page.fill('[data-testid="chat-input"]', 'Test message for persistence');
+    await page.click('[data-testid="chat-submit"]');
+
+    const userMessage = page.locator('[data-testid="user-message"]').last();
+    await expect(userMessage).toBeVisible({ timeout: 15000 });
+    await expect(userMessage).toHaveText(/Test message for persistence/);
+
+    // Wait for the response to complete and URL to update
+    const botMessage = page.locator('[data-testid="bot-message"]').last();
+    await expect(botMessage).toBeVisible({ timeout: 30000 });
+
+    // Wait for URL to update to /search/[id]
+    await expect(page).toHaveURL(/\/search\/[a-zA-Z0-9\-]+/, { timeout: 10000 });
+
+    // Navigate to home (new chat)
+    await page.goto('/');
+    await page.waitForSelector('[data-testid="chat-input"]');
+
+    // Verify the new chat page is empty
+    const emptyScreen = page.locator('[data-testid="empty-screen"]');
+    await expect(emptyScreen).toBeVisible({ timeout: 5000 });
+
+    // Navigate back to the search page to verify retrieval
+    // Get the current search URL from history
+    await page.goBack();
+    await page.waitForSelector('[data-testid="chat-input"]');
+
+    // The previous chat messages should be visible
+    const retrievedUserMessage = page.locator('[data-testid="user-message"]').last();
+    await expect(retrievedUserMessage).toBeVisible({ timeout: 10000 });
+    await expect(retrievedUserMessage).toHaveText(/Test message for persistence/);
+  });
+
+  test('should save multiple chats independently', async ({ page }) => {
+    // First chat
+    await page.fill('[data-testid="chat-input"]', 'First chat message');
+    await page.click('[data-testid="chat-submit"]');
+    const firstMessage = page.locator('[data-testid="user-message"]').last();
+    await expect(firstMessage).toBeVisible({ timeout: 15000 });
+
+    const botResponse = page.locator('[data-testid="bot-message"]').last();
+    await expect(botResponse).toBeVisible({ timeout: 30000 });
+    await expect(page).toHaveURL(/\/search\/[a-zA-Z0-9\-]+/, { timeout: 10000 });
+
+    // Save the first chat URL
+    const firstChatUrl = page.url();
+
+    // New chat
+    await page.click('[data-testid="new-chat-button"]');
+    await page.waitForSelector('[data-testid="chat-input"]');
+
+    // Second chat
+    await page.fill('[data-testid="chat-input"]', 'Second chat message');
+    await page.click('[data-testid="chat-submit"]');
+    const secondMessage = page.locator('[data-testid="user-message"]').last();
+    await expect(secondMessage).toBeVisible({ timeout: 15000 });
+    await expect(secondMessage).toHaveText(/Second chat message/);
+
+    const secondBotResponse = page.locator('[data-testid="bot-message"]').last();
+    await expect(secondBotResponse).toBeVisible({ timeout: 30000 });
+
+    // Navigate back to first chat
+    await page.goto(firstChatUrl);
+    await page.waitForSelector('[data-testid="chat-input"]');
+
+    // First chat should still have its message
+    const retrievedFirstMessage = page.locator('[data-testid="user-message"]').last();
+    await expect(retrievedFirstMessage).toBeVisible({ timeout: 10000 });
+    await expect(retrievedFirstMessage).toHaveText(/First chat message/);
+  });
+
+  test('should persist chat after page reload', async ({ page }) => {
+    // Send a message
+    await page.fill('[data-testid="chat-input"]', 'Persist across reload test');
+    await page.click('[data-testid="chat-submit"]');
+
+    const userMessage = page.locator('[data-testid="user-message"]').last();
+    await expect(userMessage).toBeVisible({ timeout: 15000 });
+    await expect(userMessage).toHaveText(/Persist across reload test/);
+
+    const botMessage = page.locator('[data-testid="bot-message"]').last();
+    await expect(botMessage).toBeVisible({ timeout: 30000 });
+
+    // Wait for URL to update
+    await expect(page).toHaveURL(/\/search\/[a-zA-Z0-9\-]+/, { timeout: 10000 });
+
+    // Reload the page
+    await page.reload();
+    await page.waitForSelector('[data-testid="chat-input"]');
+
+    // Verify messages are still visible after reload
+    const persistedUserMessage = page.locator('[data-testid="user-message"]').last();
+    await expect(persistedUserMessage).toBeVisible({ timeout: 10000 });
+    await expect(persistedUserMessage).toHaveText(/Persist across reload test/);
+  });
+});
+
+test.describe('Chat History Clearing', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector('[data-testid="chat-input"]');
+  });
+
+  test('should clear history without crashing', async ({ page }) => {
+    // Create a chat first
+    await page.fill('[data-testid="chat-input"]', 'Message before clear');
+    await page.click('[data-testid="chat-submit"]');
+    const userMessage = page.locator('[data-testid="user-message"]').last();
+    await expect(userMessage).toBeVisible({ timeout: 15000 });
+
+    const botMessage = page.locator('[data-testid="bot-message"]').last();
+    await expect(botMessage).toBeVisible({ timeout: 30000 });
+
+    // Wait for URL to update
+    await expect(page).toHaveURL(/\/search\/[a-zA-Z0-9\-]+/, { timeout: 10000 });
+
+    // Open history panel
+    await page.click('[data-testid="history-button"]');
+    const historyPanel = page.locator('[data-testid="history-panel"]');
+    await expect(historyPanel).toBeVisible({ timeout: 5000 });
+
+    // Click clear history button
+    await page.click('[data-testid="clear-history-button"]');
+
+    // Confirm in the dialog
+    await page.click('[data-testid="clear-history-confirm"]');
+
+    // Wait for the redirect to home
+    await expect(page).toHaveURL('http://localhost:3000/', { timeout: 10000 });
+
+    // Verify we're on a clean page
+    const emptyScreen = page.locator('[data-testid="empty-screen"]');
+    await expect(emptyScreen).toBeVisible({ timeout: 5000 });
+  });
+
+  test('should clear history multiple times without error', async ({ page }) => {
+    // Create first chat
+    await page.fill('[data-testid="chat-input"]', 'First message');
+    await page.click('[data-testid="chat-submit"]');
+    const botMessage = page.locator('[data-testid="bot-message"]').last();
+    await expect(botMessage).toBeVisible({ timeout: 30000 });
+
+    // Open history and clear
+    await page.click('[data-testid="history-button"]');
+    await page.click('[data-testid="clear-history-button"]');
+    await page.click('[data-testid="clear-history-confirm"]');
+    await expect(page).toHaveURL('http://localhost:3000/', { timeout: 10000 });
+
+    // Wait a moment for the app to settle
+    await page.waitForTimeout(1000);
+
+    // Create second chat
+    await page.fill('[data-testid="chat-input"]', 'Second message');
+    await page.click('[data-testid="chat-submit"]');
+    const secondBotMessage = page.locator('[data-testid="bot-message"]').last();
+    await expect(secondBotMessage).toBeVisible({ timeout: 30000 });
+
+    // Open history and clear again
+    await page.click('[data-testid="history-button"]');
+    await page.click('[data-testid="clear-history-button"]');
+    await page.click('[data-testid="clear-history-confirm"]');
+    await expect(page).toHaveURL('http://localhost:3000/', { timeout: 10000 });
+
+    // Verify clean state
+    const emptyScreen = page.locator('[data-testid="empty-screen"]');
+    await expect(emptyScreen).toBeVisible({ timeout: 5000 });
+  });
+
+  test('should not crash when clearing history from a /search/[id] page', async ({ page }) => {
+    // Create a chat and navigate to it
+    await page.fill('[data-testid="chat-input"]', 'Clear from search page');
+    await page.click('[data-testid="chat-submit"]');
+    const botMessage = page.locator('[data-testid="bot-message"]').last();
+    await expect(botMessage).toBeVisible({ timeout: 30000 });
+    await expect(page).toHaveURL(/\/search\/[a-zA-Z0-9\-]+/, { timeout: 10000 });
+
+    // Open history panel while on the search page
+    await page.click('[data-testid="history-button"]');
+    await expect(page.locator('[data-testid="history-panel"]')).toBeVisible({ timeout: 5000 });
+
+    // Clear history
+    await page.click('[data-testid="clear-history-button"]');
+    await page.click('[data-testid="clear-history-confirm"]');
+
+    // Should redirect to home without crashing
+    await expect(page).toHaveURL('http://localhost:3000/', { timeout: 10000 });
+
+    // Verify no error or crash
+    await expect(page.locator('[data-testid="chat-input"]')).toBeVisible({ timeout: 5000 });
+  });
+
+  test('should show empty history after clearing', async ({ page }) => {
+    // Create a chat
+    await page.fill('[data-testid="chat-input"]', 'History test message');
+    await page.click('[data-testid="chat-submit"]');
+    const botMessage = page.locator('[data-testid="bot-message"]').last();
+    await expect(botMessage).toBeVisible({ timeout: 30000 });
+
+    // Open history and verify items exist
+    await page.click('[data-testid="history-button"]');
+    const historyItems = page.locator('[data-testid^="history-item-"]');
+    await expect(historyItems.first()).toBeVisible({ timeout: 5000 });
+
+    // Clear history
+    await page.click('[data-testid="clear-history-button"]');
+    await page.click('[data-testid="clear-history-confirm"]');
+    await expect(page).toHaveURL('http://localhost:3000/', { timeout: 10000 });
+
+    // Open history and verify it's empty
+    await page.click('[data-testid="history-button"]');
+    const noHistoryText = page.locator('text=No search history');
+    await expect(noHistoryText).toBeVisible({ timeout: 5000 });
+  });
+});
+
+test.describe('Chat Save for All Message Types', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector('[data-testid="chat-input"]');
+  });
+
+  test('should save chat even without a response message type', async ({ page }) => {
+    // Send a message and wait for the chat to be saved
+    await page.fill('[data-testid="chat-input"]', 'Save test without response type');
+    await page.click('[data-testid="chat-submit"]');
+
+    const userMessage = page.locator('[data-testid="user-message"]').last();
+    await expect(userMessage).toBeVisible({ timeout: 15000 });
+
+    // Wait for the bot response
+    const botMessage = page.locator('[data-testid="bot-message"]').last();
+    await expect(botMessage).toBeVisible({ timeout: 30000 });
+
+    // Verify URL updated (indicating chat was saved)
+    await expect(page).toHaveURL(/\/search\/[a-zA-Z0-9\-]+/, { timeout: 10000 });
+
+    // Navigate to home and back to verify persistence
+    await page.goto('/');
+    await page.waitForSelector('[data-testid="chat-input"]');
+
+    // Go back to the search page
+    await page.goBack();
+    await page.waitForSelector('[data-testid="chat-input"]');
+
+    // Messages should still be visible
+    const retrievedMessage = page.locator('[data-testid="user-message"]').last();
+    await expect(retrievedMessage).toBeVisible({ timeout: 10000 });
+    await expect(retrievedMessage).toHaveText(/Save test without response type/);
+  });
+});

--- a/tests/unit/chat-db.spec.ts
+++ b/tests/unit/chat-db.spec.ts
@@ -1,0 +1,176 @@
+/**
+ * Unit tests for chat-db.ts functions.
+ * These test the save/retrieve logic including messageType and messageName persistence.
+ * Run with: npx vitest run tests/unit/chat-db.spec.ts
+ */
+
+// Mock the database module
+const mockDbTransaction = jest.fn();
+const mockDbDelete = jest.fn();
+const mockDbSelect = jest.fn();
+const mockDbInsert = jest.fn();
+
+jest.mock('@/lib/db', () => ({
+  db: {
+    transaction: (...args: any[]) => mockDbTransaction(...args),
+    delete: jest.fn(() => ({
+      where: jest.fn(() => mockDbDelete()),
+    })),
+    select: jest.fn(() => ({
+      from: jest.fn(() => ({
+        where: jest.fn(() => ({
+          limit: jest.fn(() => mockDbSelect()),
+          orderBy: jest.fn(() => ({
+            limit: jest.fn(() => mockDbSelect()),
+          })),
+        })),
+      })),
+    })),
+    insert: jest.fn(() => ({
+      values: jest.fn(() => ({
+        returning: jest.fn(() => mockDbInsert()),
+        onConflictDoUpdate: jest.fn(() => Promise.resolve()),
+      })),
+    })),
+  },
+}));
+
+jest.mock('@/lib/auth/get-current-user', () => ({
+  getCurrentUserIdOnServer: jest.fn().mockResolvedValue('test-user-uuid'),
+}));
+
+import { clearHistory, saveChat, getMessagesByChatId } from '@/lib/actions/chat-db';
+
+describe('chat-db', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('clearHistory', () => {
+    it('should delete all chats for the user', async () => {
+      mockDbDelete.mockResolvedValue(undefined);
+      const result = await clearHistory('test-user-uuid');
+      expect(result).toBe(true);
+    });
+
+    it('should return false when userId is missing', async () => {
+      const result = await clearHistory('');
+      expect(result).toBe(false);
+    });
+
+    it('should retry on failure', async () => {
+      let callCount = 0;
+      mockDbDelete.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          throw new Error('Connection timeout');
+        }
+        return Promise.resolve(undefined);
+      });
+      const result = await clearHistory('test-user-uuid');
+      expect(result).toBe(true);
+      expect(callCount).toBe(2);
+    });
+
+    it('should return false after max retries exhausted', async () => {
+      mockDbDelete.mockRejectedValue(new Error('Connection refused'));
+      const result = await clearHistory('test-user-uuid');
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('saveChat', () => {
+    it('should return null when chatData has no userId', async () => {
+      const result = await saveChat(
+        { userId: undefined as any, title: 'Test' },
+        []
+      );
+      expect(result).toBe(null);
+    });
+
+    it('should persist messageType and messageName fields', async () => {
+      mockDbTransaction.mockImplementation(async (fn) => {
+        const mockTx = {
+          select: jest.fn().mockResolvedValue([]),
+          insert: jest.fn().mockReturnValue({
+            values: jest.fn().mockReturnValue({
+              returning: jest.fn().mockResolvedValue([{ id: 'new-chat-id' }]),
+            }),
+          }),
+        };
+        return fn(mockTx);
+      });
+
+      const messagesWithTypes = [
+        {
+          id: 'msg-1',
+          role: 'user',
+          content: 'Hello',
+          messageType: 'input',
+          messageName: null,
+          userId: 'test-user-uuid',
+        },
+        {
+          id: 'msg-2',
+          role: 'assistant',
+          content: 'Hi there',
+          messageType: 'response',
+          messageName: null,
+          userId: 'test-user-uuid',
+        },
+        {
+          id: 'msg-3',
+          role: 'tool',
+          content: 'Search results',
+          messageType: 'tool',
+          messageName: 'search',
+          userId: 'test-user-uuid',
+        },
+      ];
+
+      const result = await saveChat(
+        { id: 'chat-123', userId: 'test-user-uuid', title: 'Test Chat' },
+        messagesWithTypes as any
+      );
+
+      expect(result).toBe('chat-123');
+    });
+  });
+
+  describe('getMessagesByChatId', () => {
+    it('should return messages with messageType and messageName', async () => {
+      mockDbSelect.mockResolvedValue([
+        {
+          id: 'msg-1',
+          chatId: 'chat-123',
+          userId: 'test-user-uuid',
+          role: 'user',
+          content: 'Hello',
+          messageType: 'input',
+          messageName: null,
+          createdAt: new Date(),
+        },
+        {
+          id: 'msg-2',
+          chatId: 'chat-123',
+          userId: 'test-user-uuid',
+          role: 'assistant',
+          content: 'Hi there',
+          messageType: 'response',
+          messageName: null,
+          createdAt: new Date(),
+        },
+      ]);
+
+      const messages = await getMessagesByChatId('chat-123');
+      expect(messages).toHaveLength(2);
+      expect(messages[0].messageType).toBe('input');
+      expect(messages[1].messageType).toBe('response');
+    });
+
+    it('should return empty array when chatId is missing', async () => {
+      const messages = await getMessagesByChatId('');
+      expect(messages).toEqual([]);
+    });
+  });
+});

--- a/tests/unit/chat-save.spec.ts
+++ b/tests/unit/chat-save.spec.ts
@@ -1,0 +1,152 @@
+/**
+ * Unit tests for chat.ts saveChat function.
+ * Tests that the AIMessage -> DbNewMessage mapping correctly preserves
+ * type and name fields.
+ */
+
+// Mock all dependencies
+jest.mock('@/lib/db', () => ({
+  db: {
+    select: jest.fn().mockReturnValue({
+      from: jest.fn().mockReturnValue({
+        where: jest.fn().mockReturnValue({
+          limit: jest.fn().mockResolvedValue([{ id: 'test-user-uuid' }]),
+        }),
+      }),
+    }),
+  },
+}));
+
+jest.mock('@/lib/actions/chat-db', () => ({
+  getChatsPage: jest.fn().mockResolvedValue({ chats: [], nextOffset: null }),
+  getChat: jest.fn().mockResolvedValue(null),
+  clearHistory: jest.fn().mockResolvedValue(true),
+  saveChat: jest.fn().mockResolvedValue('saved-chat-id'),
+  createMessage: jest.fn(),
+  getMessagesByChatId: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('@/lib/auth/get-current-user', () => ({
+  getCurrentUserIdOnServer: jest.fn().mockResolvedValue('test-user-uuid'),
+}));
+
+jest.mock('../utils', () => ({
+  getModel: jest.fn(),
+  normalizeMessageContent: jest.fn((content) =>
+    typeof content === 'string' ? content : JSON.stringify(content)
+  ),
+}));
+
+jest.mock('../agents/report/executive-summary', () => ({
+  executiveSummaryAgent: jest.fn(),
+}));
+
+jest.mock('../agents/report/strategic-synthesis', () => ({
+  strategicSynthesisAgent: jest.fn(),
+}));
+
+import { saveChat } from '@/lib/actions/chat';
+import { saveChat as dbSaveChat } from '@/lib/actions/chat-db';
+
+describe('chat.ts saveChat mapping', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should map type field to messageType in DB messages', async () => {
+    const chat = {
+      id: 'chat-123',
+      createdAt: new Date(),
+      userId: 'test-user-uuid',
+      path: '/search/chat-123',
+      title: 'Test Chat',
+      messages: [
+        {
+          id: 'msg-1',
+          role: 'user',
+          content: 'Hello world',
+          type: 'input',
+          createdAt: new Date(),
+        },
+        {
+          id: 'msg-2',
+          role: 'assistant',
+          content: 'Hi there!',
+          type: 'response',
+          createdAt: new Date(),
+        },
+        {
+          id: 'msg-3',
+          role: 'tool',
+          content: 'Search results',
+          type: 'tool',
+          name: 'search',
+          createdAt: new Date(),
+        },
+      ],
+    };
+
+    await saveChat(chat, 'test-user-uuid');
+
+    // Verify dbSaveChat was called
+    expect(dbSaveChat).toHaveBeenCalled();
+    const callArgs = (dbSaveChat as jest.Mock).mock.calls[0];
+    const messagesData = callArgs[1]; // Second argument is messages
+
+    // Verify messageType was mapped correctly
+    expect(messagesData[0].messageType).toBe('input');
+    expect(messagesData[1].messageType).toBe('response');
+    expect(messagesData[2].messageType).toBe('tool');
+    expect(messagesData[2].messageName).toBe('search');
+  });
+
+  it('should handle messages without type field (null)', async () => {
+    const chat = {
+      id: 'chat-456',
+      createdAt: new Date(),
+      userId: 'test-user-uuid',
+      path: '/search/chat-456',
+      title: 'Test Chat 2',
+      messages: [
+        {
+          id: 'msg-1',
+          role: 'user',
+          content: 'Test',
+          // No type field
+          createdAt: new Date(),
+        },
+      ],
+    };
+
+    await saveChat(chat, 'test-user-uuid');
+
+    const callArgs = (dbSaveChat as jest.Mock).mock.calls[0];
+    const messagesData = callArgs[1];
+    expect(messagesData[0].messageType).toBeNull();
+  });
+
+  it('should handle object content (JSON.stringify)', async () => {
+    const chat = {
+      id: 'chat-789',
+      createdAt: new Date(),
+      userId: 'test-user-uuid',
+      path: '/search/chat-789',
+      title: 'Test Chat 3',
+      messages: [
+        {
+          id: 'msg-1',
+          role: 'user',
+          content: [{ type: 'text', text: 'Hello' }],
+          type: 'input',
+          createdAt: new Date(),
+        },
+      ],
+    };
+
+    await saveChat(chat, 'test-user-uuid');
+
+    const callArgs = (dbSaveChat as jest.Mock).mock.calls[0];
+    const messagesData = callArgs[1];
+    expect(messagesData[0].content).toBe('[{"type":"text","text":"Hello"}]');
+  });
+});

--- a/tests/unit/message-restoration.spec.ts
+++ b/tests/unit/message-restoration.spec.ts
@@ -1,0 +1,186 @@
+/**
+ * Unit tests for the message restoration logic.
+ * Verifies that DrizzleMessage -> AIMessage mapping correctly restores
+ * type and name fields from messageType and messageName DB columns.
+ */
+
+describe('Message Restoration (search/[id] page)', () => {
+  describe('DrizzleMessage to AIMessage mapping', () => {
+    it('should restore type from messageType column', () => {
+      const dbMessages = [
+        {
+          id: 'msg-1',
+          chatId: 'chat-123',
+          userId: 'user-1',
+          role: 'user',
+          content: 'Hello',
+          messageType: 'input',
+          messageName: null,
+          createdAt: new Date(),
+        },
+        {
+          id: 'msg-2',
+          chatId: 'chat-123',
+          userId: 'user-1',
+          role: 'assistant',
+          content: 'Hi there!',
+          messageType: 'response',
+          messageName: null,
+          createdAt: new Date(),
+        },
+        {
+          id: 'msg-3',
+          chatId: 'chat-123',
+          userId: 'user-1',
+          role: 'tool',
+          content: 'Search results',
+          messageType: 'tool',
+          messageName: 'search',
+          createdAt: new Date(),
+        },
+        {
+          id: 'msg-4',
+          chatId: 'chat-123',
+          userId: 'user-1',
+          role: 'assistant',
+          content: 'Related topics',
+          messageType: 'related',
+          messageName: null,
+          createdAt: new Date(),
+        },
+        {
+          id: 'msg-5',
+          chatId: 'chat-123',
+          userId: 'user-1',
+          role: 'assistant',
+          content: 'Follow-up question',
+          messageType: 'followup',
+          messageName: null,
+          createdAt: new Date(),
+        },
+      ];
+
+      // Simulate the mapping logic from search/[id]/page.tsx
+      const initialMessages = dbMessages.map((dbMsg: any) => ({
+        id: dbMsg.id,
+        role: dbMsg.role,
+        content: dbMsg.content,
+        type: dbMsg.messageType || undefined,
+        name: dbMsg.messageName || undefined,
+        createdAt: dbMsg.createdAt,
+      }));
+
+      // Verify type restoration
+      expect(initialMessages[0].type).toBe('input');
+      expect(initialMessages[1].type).toBe('response');
+      expect(initialMessages[2].type).toBe('tool');
+      expect(initialMessages[2].name).toBe('search');
+      expect(initialMessages[3].type).toBe('related');
+      expect(initialMessages[4].type).toBe('followup');
+    });
+
+    it('should handle null messageType gracefully', () => {
+      const dbMessages = [
+        {
+          id: 'msg-1',
+          chatId: 'chat-123',
+          userId: 'user-1',
+          role: 'user',
+          content: 'Hello',
+          messageType: null,
+          messageName: null,
+          createdAt: new Date(),
+        },
+      ];
+
+      const initialMessages = dbMessages.map((dbMsg: any) => ({
+        id: dbMsg.id,
+        role: dbMsg.role,
+        content: dbMsg.content,
+        type: dbMsg.messageType || undefined,
+        name: dbMsg.messageName || undefined,
+        createdAt: dbMsg.createdAt,
+      }));
+
+      expect(initialMessages[0].type).toBeUndefined();
+      expect(initialMessages[0].name).toBeUndefined();
+    });
+
+    it('should preserve all required fields for rendering', () => {
+      const dbMessages = [
+        {
+          id: 'msg-1',
+          chatId: 'chat-123',
+          userId: 'user-1',
+          role: 'user',
+          content: 'What is the capital of France?',
+          messageType: 'input',
+          messageName: null,
+          createdAt: new Date('2024-01-15T10:30:00Z'),
+        },
+        {
+          id: 'msg-2',
+          chatId: 'chat-123',
+          userId: 'user-1',
+          role: 'assistant',
+          content: 'The capital of France is Paris.',
+          messageType: 'response',
+          messageName: null,
+          createdAt: new Date('2024-01-15T10:30:05Z'),
+        },
+      ];
+
+      const initialMessages = dbMessages.map((dbMsg: any) => ({
+        id: dbMsg.id,
+        role: dbMsg.role,
+        content: dbMsg.content,
+        type: dbMsg.messageType || undefined,
+        name: dbMsg.messageName || undefined,
+        createdAt: dbMsg.createdAt,
+      }));
+
+      // Verify all fields needed for UI rendering are present
+      initialMessages.forEach((msg) => {
+        expect(msg.id).toBeTruthy();
+        expect(msg.role).toBeTruthy();
+        expect(msg.content).toBeTruthy();
+        expect(msg.createdAt).toBeInstanceOf(Date);
+      });
+
+      // Verify message ordering is preserved
+      expect(initialMessages[0].id).toBe('msg-1');
+      expect(initialMessages[1].id).toBe('msg-2');
+    });
+
+    it('should handle all known message types', () => {
+      const knownTypes = [
+        'input', 'response', 'tool', 'related', 'followup',
+        'resolution_search_result', 'definition', 'end', 'image'
+      ];
+
+      const dbMessages = knownTypes.map((type, index) => ({
+        id: `msg-${index}`,
+        chatId: 'chat-123',
+        userId: 'user-1',
+        role: index % 2 === 0 ? 'user' : 'assistant',
+        content: `Content for ${type}`,
+        messageType: type,
+        messageName: type === 'tool' ? 'search' : null,
+        createdAt: new Date(),
+      }));
+
+      const initialMessages = dbMessages.map((dbMsg: any) => ({
+        id: dbMsg.id,
+        role: dbMsg.role,
+        content: dbMsg.content,
+        type: dbMsg.messageType || undefined,
+        name: dbMsg.messageName || undefined,
+        createdAt: dbMsg.createdAt,
+      }));
+
+      knownTypes.forEach((type, index) => {
+        expect(initialMessages[index].type).toBe(type);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR fixes three critical issues with the chat functionality:

## 1. Chat Not Retrievable After Save

**Root cause:** The `search/[id]/page.tsx` saved messages without the `type` field, which is critical for rendering. When `getUIStateFromAIState` tried to reconstruct the UI, it filtered out all messages lacking a `type`, making the chat appear empty.

**Fix:**
- Added `messageType` and `messageName` columns to the messages table (migration 0009)
- Updated `lib/actions/chat.ts` saveChat to persist `type` and `name` from AIMessage
- Updated `search/[id]/page.tsx` to restore `type` and `name` when rehydrating from DB
- Added type-safe validation for message types

## 2. Only First Chat Saves

**Root cause:** The `onSetAIState` handler in `app/actions.tsx` only persisted when there was a `type === 'response'` message. For definition-only flows or other special branches, no `response` message existed, so the chat was silently dropped.

**Fix:** Updated `onSetAIState` to save any chat with messages, regardless of message type.

## 3. Clear History Crash (Intermittent)

**Root cause:** Multiple race conditions:
- `router.push('/')` followed immediately by `router.refresh()` created a race where the refresh could try to re-render a page being navigated away from
- The history sheet stayed open after redirect and tried to re-fetch the deleted chat list
- Two separate clear-history components had inconsistent navigation behavior
- Transient DB connection errors on Vercel cold starts caused silent failures

**Fixes:**
- Replaced `router.push('/') + router.refresh()` with a single `router.replace('/')` with a small delay
- Close history sheet BEFORE redirecting to prevent re-fetch race
- Added retry logic with exponential backoff to `clearHistory` for transient DB errors
- Updated both `clear-history.tsx` and `chat-history-client.tsx` with consistent behavior
- Removed `redirect('/')` from server action to prevent crashes when current page was deleted

## Schema Migration

New migration `0009_add_message_type_name.sql` adds two nullable text columns:
- `message_type` — stores the AI message `type` field
- `message_name` — stores the AI message `name` field

## Testing

Added comprehensive tests:
- `tests/chat-persistence.spec.ts` — E2E Playwright tests for save, retrieval, multi-chat independence, reload persistence, and clear history behavior (8 test cases)
- `tests/unit/chat-db.spec.ts` — Unit tests for clearHistory, saveChat, getMessagesByChatId
- `tests/unit/chat-save.spec.ts` — Unit tests for AIMessage to DB message mapping
- `tests/unit/message-restoration.spec.ts` — Unit tests for DrizzleMessage to AIMessage restoration