### PR TITLE
feat(ui): Move theme settings into Settings panel with Light/Dark buttons

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -2,7 +2,6 @@
 import React from 'react'
 import Image from 'next/image'
 import { useCalendarToggle } from './calendar-toggle-context'
-import { ModeToggle } from './mode-toggle'
 import { cn } from '@/lib/utils'
 import HistoryContainer from './history-container'
 import { Button } from '@/components/ui/button'
@@ -80,8 +79,6 @@ export const Header = () => {
         <Button variant="ghost" size="icon" onClick={handleUsageToggle}>
           <TentTree className="h-[1.2rem] w-[1.2rem]" />
         </Button>
-        
-        <ModeToggle />
         
         <HistoryContainer location="header" />
       </div>

--- a/components/mobile-icons-bar.tsx
+++ b/components/mobile-icons-bar.tsx
@@ -14,13 +14,12 @@ import {
   ArrowRight,
   Plus
 } from 'lucide-react'
-import { History } from '@/components/history'
 import { MapToggle } from './map-toggle'
-import { ModeToggle } from './mode-toggle'
 import { ProfileToggle } from './profile-toggle'
 import { useCalendarToggle } from './calendar-toggle-context'
 import { useUsageToggle } from './usage-toggle-context'
 import { useProfileToggle } from './profile-toggle-context'
+import { useHistoryToggle } from './history-toggle-context'
 
 interface MobileIconsBarProps {
   onAttachmentClick: () => void;
@@ -33,6 +32,7 @@ export const MobileIconsBar: React.FC<MobileIconsBarProps> = ({ onAttachmentClic
   const { toggleCalendar } = useCalendarToggle()
   const { toggleUsage, isUsageOpen } = useUsageToggle()
   const { activeView, closeProfileView } = useProfileToggle()
+  const { toggleHistory } = useHistoryToggle()
 
   const handleUsageToggle = () => {
     // If we're about to open usage and profile is open, close profile first
@@ -67,8 +67,13 @@ export const MobileIconsBar: React.FC<MobileIconsBarProps> = ({ onAttachmentClic
       <Button variant="ghost" size="icon" data-testid="mobile-submit-button" onClick={onSubmitClick}>
         <ArrowRight className="h-[1.2rem] w-[1.2rem] transition-all rotate-0 scale-100" />
       </Button>
-      <History location="header" />
-      <ModeToggle />
+      <Button variant="ghost" size="icon" onClick={toggleHistory} data-testid="mobile-history-button">
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/>
+          <path d="M3 3v5h5"/>
+          <path d="M12 7v5l4 2"/>
+        </svg>
+      </Button>
     </div>
   )
 }

--- a/components/settings/components/settings.tsx
+++ b/components/settings/components/settings.tsx
@@ -23,6 +23,7 @@ import { getSystemPrompt, saveSystemPrompt } from "../../../lib/actions/chat"
 import { getSelectedModel, saveSelectedModel } from "../../../lib/actions/users"
 import { useCurrentUser } from "@/lib/auth/use-current-user"
 import { SettingsSkeleton } from './settings-skeleton'
+import { useTheme } from 'next-themes'
 
 // Define the form schema with enum validation for roles
 const settingsFormSchema = z.object({
@@ -62,6 +63,48 @@ const defaultValues: Partial<SettingsFormValues> = {
 
 interface SettingsProps {
   initialTab?: string;
+}
+
+function ThemeSelector() {
+  const { theme, setTheme, resolvedTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const currentTheme = mounted ? (theme === 'system' ? resolvedTheme : theme) : 'light';
+
+  const themes = [
+    { key: 'light', label: 'Light', icon: (
+      <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="m17.66 17.66 1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m6.34 17.66-1.41 1.41"/><path d="m19.07 4.93-1.41 1.41"/>
+      </svg>
+    )},
+    { key: 'dark', label: 'Dark', icon: (
+      <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/>
+      </svg>
+    )},
+  ];
+
+  return (
+    <div className="flex gap-3 w-full">
+      {themes.map((t) => (
+        <Button
+          key={t.key}
+          variant={currentTheme === t.key ? "default" : "outline"}
+          className={`flex-1 h-20 flex-col gap-2 text-sm transition-all ${
+            currentTheme === t.key ? "shadow-md" : "opacity-80 hover:opacity-100"
+          }`}
+          onClick={() => setTheme(t.key)}
+        >
+          <span className="opacity-70">{t.icon}</span>
+          <span className="font-medium">{t.label}</span>
+        </Button>
+      ))}
+    </div>
+  );
 }
 
 export function Settings({ initialTab = "system-prompt" }: SettingsProps) {
@@ -164,11 +207,12 @@ export function Settings({ initialTab = "system-prompt" }: SettingsProps) {
       <form onSubmit={form.handleSubmit(onSubmit)}>
         <div className="space-y-6">
           <Tabs.Root value={currentTab} onValueChange={setCurrentTab} className="w-full">
-            <Tabs.List className="grid w-full grid-cols-4 gap-x-2">
+            <Tabs.List className="grid w-full grid-cols-5 gap-x-2">
               <Tabs.Trigger value="system-prompt" className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2 data-[state=active]:bg-primary/80">System Prompt</Tabs.Trigger>
               <Tabs.Trigger value="model" className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2 data-[state=active]:bg-primary/80">Model Selection</Tabs.Trigger>
               <Tabs.Trigger value="user-management" className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2 data-[state=active]:bg-primary/80">User Management</Tabs.Trigger>
               <Tabs.Trigger value="map" className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2 data-[state=active]:bg-primary/80">Map</Tabs.Trigger>
+              <Tabs.Trigger value="appearance" className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2 data-[state=active]:bg-primary/80">Appearance</Tabs.Trigger>
             </Tabs.List>
             <AnimatePresence mode="wait">
               <motion.div
@@ -226,6 +270,17 @@ export function Settings({ initialTab = "system-prompt" }: SettingsProps) {
                           <Label htmlFor="google">Google Maps</Label>
                         </div>
                       </RadioGroup>
+                    </CardContent>
+                  </Card>
+                </Tabs.Content>
+                <Tabs.Content value="appearance" className="mt-6">
+                  <Card>
+                    <CardHeader>
+                      <CardTitle>Appearance</CardTitle>
+                      <CardDescription>Choose your preferred theme for the application</CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                      <ThemeSelector />
                     </CardContent>
                   </Card>
                 </Tabs.Content>


### PR DESCRIPTION
## Summary of Changes

This pull request consolidates the theme settings into the Settings panel and replaces the theme toggle button on the mobile UI with a chat history toggle button.

### Changes Made

**1. Theme Settings Moved into Settings Panel**
- Added a new **Appearance** tab to the Settings panel alongside System Prompt, Model Selection, User Management, and Map
- Theme selection is now presented as styled buttons with icons (Light and Dark only)
- Removed the **System** and **Earth** theme options — only **Light** and **Dark** remain
- Buttons are styled to blend seamlessly with the existing card-based settings design

**2. Mobile UI — Theme Toggle Replaced with History Toggle**
- Replaced the  (theme change button) on the mobile icons bar with a **Chat History** toggle button
- The history button uses a clock/history icon to toggle the chat history sidebar

**3. Desktop UI — Theme Toggle Removed from Header**
- Removed the  from the desktop header navigation bar
- The header now only shows the relevant action icons without a dedicated theme switcher

### Files Modified
-  — Added Appearance tab with ThemeSelector component (Light/Dark buttons)
-  — Replaced ModeToggle with History toggle button
-  — Removed ModeToggle from desktop header

### How to Test
1. Navigate to the Settings panel (via Profile > Settings)
2. The new **Appearance** tab should be visible as the 5th tab
3. Click Light or Dark to switch themes
4. On mobile, the theme icon should be replaced with a history toggle button
5. On desktop, the theme toggle should no longer appear in the header

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Appearance section in Settings with Light and Dark theme options.
  * Added a history button to the mobile navigation bar.

* **Changes**
  * Removed the mode toggle from the desktop header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->