### PR TITLE
Comment out bottom-left SWUpdateNotification popup

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,7 +21,7 @@ import { HistorySidebar } from '@/components/history-sidebar'
 import { MapLoadingProvider } from '@/components/map-loading-context';
 import ConditionalLottie from '@/components/conditional-lottie';
 import { MapProvider as MapContextProvider } from '@/components/map/map-context'
-import { SWUpdateNotification } from '@/components/sw-update-notification'
+// import { SWUpdateNotification } from '@/components/sw-update-notification'
 
 const fontSans = FontSans({
   subsets: ['latin'],
@@ -130,7 +130,7 @@ export default function RootLayout({
                         <HistorySidebar />
                         <Footer />
                         <Toaster />
-                        <SWUpdateNotification />
+                        {/* <SWUpdateNotification /> */}
                       </MapLoadingProvider>
                     </MapContextProvider>
                   </ThemeProvider>


### PR DESCRIPTION
Commented out the SWUpdateNotification component in app/layout.tsx, which displayed a service worker update notification popup at the bottom-left of the screen.

**Changes:**
- Commented out the `SWUpdateNotification` component usage in `app/layout.tsx`
- Commented out the corresponding import statement

This removes the "A new version is available!" toast notification that appeared at the bottom-left of the screen, prompting users to reload.
