### PR TITLE
chore: gitignore .foglamp and configure scan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ edge_function/
 
 # clerk configuration (can include secrets)
 /.clerk/
+
+# foglamp architecture scans (contains secrets like editToken)
+/.foglamp/


### PR DESCRIPTION
Configured the QCX codebase architecture scan mapping of models, tools, and integrations, and published it to foglamp.dev. Verified that `.foglamp` is successfully ignored.

---
*PR created automatically by Jules for task [5442431678675155157](https://jules.google.com/task/5442431678675155157) started by @ngoiyaeric*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Excluded Foglamp architecture scan outputs from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->