### PR TITLE
Implement equidistant spacing for mobile navigation icons

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -149,10 +149,10 @@
 
   .mobile-icons-bar-content {
     display: flex;
-    gap: 16px;
-    padding: 0 10px;
-    min-width: max-content;
-    justify-content: flex-start;
+    width: 100%;
+    min-width: 100%;
+    padding: 0 12px;
+    justify-content: space-between;
   }
 
   .mobile-icons-bar-content > * {


### PR DESCRIPTION
This PR updates the CSS styles for `.mobile-icons-bar-content` under `@media (max-width: 1024px)` to expand to 100% width and utilize `justify-content: space-between` instead of a fixed gap with left-aligned layout. This solves the uneven spacing issue by spreading the icons across the full width of the mobile container with equidistant horizontal spacing on both sides.

---
*PR created automatically by Jules for task [14963222283663131479](https://jules.google.com/task/14963222283663131479) started by @ngoiyaeric*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the mobile icon bar layout so items evenly fill the available width.
  * Added consistent horizontal padding for better spacing on mobile screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->