### PR TITLE
Add tactile physical press-down effect to buttons

### DIFF
--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-all duration-75 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 active:translate-y-[1px] active:scale-[0.97] active:shadow-inner active:brightness-95 disabled:pointer-events-none disabled:opacity-50',
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-all duration-75 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 border border-border/80 shadow-[2px_3px_0px_rgba(0,0,0,0.35)] dark:shadow-[2px_3px_0px_rgba(255,255,255,0.2)] active:translate-y-[2px] active:translate-x-[1px] active:scale-[0.96] active:shadow-[inset_2px_2px_4px_rgba(0,0,0,0.4)] aria-pressed:translate-y-[2px] aria-pressed:translate-x-[1px] aria-pressed:shadow-[inset_2px_2px_4px_rgba(0,0,0,0.4)] aria-pressed:bg-accent/80 data-[state=open]:translate-y-[2px] data-[state=open]:translate-x-[1px] data-[state=open]:shadow-[inset_2px_2px_4px_rgba(0,0,0,0.4)] data-[state=open]:bg-accent/80 data-[pressed=true]:translate-y-[2px] data-[pressed=true]:translate-x-[1px] data-[pressed=true]:shadow-[inset_2px_2px_4px_rgba(0,0,0,0.4)] data-[pressed=true]:bg-accent/80 disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
       variant: {

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-all duration-75 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 active:translate-y-[1px] active:scale-[0.97] active:shadow-inner active:brightness-95 disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
       variant: {


### PR DESCRIPTION
Added physical press-down interaction states to buttonVariants in components/ui/button.tsx using active:translate-y-[1px], active:scale-[0.97], active:shadow-inner, and active:brightness-95 with smooth transitions.

---
*PR created automatically by Jules for task [15546493193107537089](https://jules.google.com/task/15546493193107537089) started by @ngoiyaeric*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved button responsiveness with faster visual transitions.
  * Added pressed-state feedback, including subtle movement, scaling, shadow, and brightness effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->