### PR TITLE
Hide Mapbox logo and attribution wording on map

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -263,3 +263,12 @@
 .mapboxgl-ctrl-group button {
   pointer-events: auto !important;
 }
+
+/* Hide Mapbox logo, attribution, and bottom controls */
+.mapboxgl-ctrl-bottom-left,
+.mapboxgl-ctrl-bottom-right,
+.mapboxgl-ctrl-logo,
+.mapboxgl-ctrl-attrib,
+.mapboxgl-compact {
+  display: none !important;
+}

--- a/components/map/mapbox-map.tsx
+++ b/components/map/mapbox-map.tsx
@@ -406,7 +406,7 @@ export const Mapbox: React.FC<{ position?: { latitude: number; longitude: number
           pitch: initialPitch,
           bearing: initialBearing,
           maxZoom: 22,
-          attributionControl: true,
+          attributionControl: false,
           preserveDrawingBuffer: true
         })
 


### PR DESCRIPTION
Disables Mapbox attribution control and adds CSS overrides to hide Mapbox branding, copyright text, and bottom control containers from the map view.

---
*PR created automatically by Jules for task [17191172427941530067](https://jules.google.com/task/17191172427941530067) started by @ngoiyaeric*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the map presentation by hiding Mapbox branding, attribution text, and built-in corner controls.
  - Simplified the map interface for a cleaner, less visually crowded experience.
  - Disabled the default attribution control to keep the map display streamlined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->