### PR TITLE
Switch default AI model provider to OpenAI

### DIFF
--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -86,7 +86,7 @@ export async function getModel(requireVision: boolean = false) {
       const openai = createOpenAI({
         apiKey: openaiApiKey,
       });
-      return openai('gpt-4o');
+      return openai('gpt-5.6-terra');
     } catch (error) {
       console.warn('OpenAI API unavailable, falling back to next provider:', error);
     }

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -80,7 +80,18 @@ export async function getModel(requireVision: boolean = false) {
     }
   }
 
-  // Default behavior: Grok -> Gemini -> Bedrock -> OpenAI
+  // Default behavior: OpenAI -> Grok -> Gemini -> Bedrock
+  if (openaiApiKey) {
+    try {
+      const openai = createOpenAI({
+        apiKey: openaiApiKey,
+      });
+      return openai('gpt-4o');
+    } catch (error) {
+      console.warn('OpenAI API unavailable, falling back to next provider:', error);
+    }
+  }
+
   if (xaiApiKey) {
     const xai = createXai({
       apiKey: xaiApiKey,
@@ -90,7 +101,7 @@ export async function getModel(requireVision: boolean = false) {
       const modelId = requireVision ? 'grok-latest' : 'grok-latest';
       return xai(modelId);
     } catch (error) {
-      console.warn('xAI API unavailable, falling back to next provider:');
+      console.warn('xAI API unavailable, falling back to next provider:', error);
     }
   }
 


### PR DESCRIPTION
Updated getModel in lib/utils/index.ts to prioritize OpenAI models (gpt-4o) as the primary default AI provider while maintaining xAI, Gemini, and Bedrock as fallbacks.

---
*PR created automatically by Jules for task [2726918557220309192](https://jules.google.com/task/2726918557220309192) started by @ngoiyaeric*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI provider fallback behavior by trying OpenAI first, then automatically continuing to alternate providers if initialization fails.
  * Added clearer warning details when switching providers after an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->