### PR TITLE
Fix OpenAI model identifier for resolution search

### DIFF
--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -86,7 +86,7 @@ export async function getModel(requireVision: boolean = false) {
       const openai = createOpenAI({
         apiKey: openaiApiKey,
       });
-      return openai('gpt-5.6-terra');
+      return openai('gpt-4o');
     } catch (error) {
       console.warn('OpenAI API unavailable, falling back to next provider:', error);
     }


### PR DESCRIPTION
Fix issue where OpenAI model fails to respond and process multimodal image resolution search due to an invalid model identifier 'gpt-5.6-terra'. Updated fallback model in `lib/utils/index.ts` to `gpt-4o`.

---
*PR created automatically by Jules for task [12761754023588497682](https://jules.google.com/task/12761754023588497682) started by @ngoiyaeric*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default AI model selection to use GPT-4o, improving fallback compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->