### PR TITLE
Fix default OpenAI model ID for resolution search

### DIFF
--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -86,7 +86,7 @@ export async function getModel(requireVision: boolean = false) {
       const openai = createOpenAI({
         apiKey: openaiApiKey,
       });
-      return openai('gpt-5.6-terra');
+      return openai('gpt-4o');
     } catch (error) {
       console.warn('OpenAI API unavailable, falling back to next provider:', error);
     }


### PR DESCRIPTION
Fix issue where OpenAI provider in getModel fallback attempted to instantiate non-existent model 'gpt-5.6-terra', causing resolution search and default OpenAI calls to fail.

---
*PR created automatically by Jules for task [15929876514078722655](https://jules.google.com/task/15929876514078722655) started by @ngoiyaeric*