### PR TITLE
Fix OpenAI Model Identifier and Resolution Search Schema Compatibility

### DIFF
--- a/app/actions.tsx
+++ b/app/actions.tsx
@@ -157,11 +157,13 @@ async function submit(formData?: FormData, skip?: boolean) {
             geoJson = {
               type: 'FeatureCollection',
               features: analysisResult.geoJson.features.map(f => {
-                let parsedCoords: any = [];
-                try {
-                  parsedCoords = typeof f.coordinates === 'string' ? JSON.parse(f.coordinates) : f.coordinates;
-                } catch (e) {
-                  console.error('Failed to parse feature coordinates:', e);
+                let parsedCoords: any = f.coordinates;
+                if (typeof parsedCoords === 'string') {
+                  try {
+                    parsedCoords = JSON.parse(parsedCoords);
+                  } catch (e) {
+                    console.error('Failed to parse feature coordinates:', e);
+                  }
                 }
                 return {
                   type: 'Feature',

--- a/app/actions.tsx
+++ b/app/actions.tsx
@@ -156,17 +156,25 @@ async function submit(formData?: FormData, skip?: boolean) {
           if (analysisResult.geoJson && analysisResult.geoJson.features) {
             geoJson = {
               type: 'FeatureCollection',
-              features: analysisResult.geoJson.features.map(f => ({
-                type: 'Feature',
-                geometry: {
-                  type: f.geometryType as any,
-                  coordinates: f.coordinates as any
-                },
-                properties: {
-                  name: f.name,
-                  description: f.description
+              features: analysisResult.geoJson.features.map(f => {
+                let parsedCoords: any = [];
+                try {
+                  parsedCoords = typeof f.coordinates === 'string' ? JSON.parse(f.coordinates) : f.coordinates;
+                } catch (e) {
+                  console.error('Failed to parse feature coordinates:', e);
                 }
-              }))
+                return {
+                  type: 'Feature',
+                  geometry: {
+                    type: f.geometryType as any,
+                    coordinates: parsedCoords
+                  },
+                  properties: {
+                    name: f.name,
+                    description: f.description
+                  }
+                };
+              })
             };
           }
 

--- a/app/actions.tsx
+++ b/app/actions.tsx
@@ -151,31 +151,50 @@ async function submit(formData?: FormData, skip?: boolean) {
           const analysisResult = await streamResult.object;
           summaryStream.done(analysisResult.summary || 'Analysis complete.');
 
-          // Reconstruct standard GeoJSON from flattened schema if present
+          // Reconstruct standard GeoJSON from flattened schema if present.
+          // Structured-output models should return flat Point coordinates, but
+          // validate recursively so malformed or legacy nested data cannot
+          // reach the map layer or persisted assistant state.
+          const isValidCoordinates = (value: unknown): value is number[] | unknown[] => {
+            if (!Array.isArray(value) || value.length === 0) return false
+            return value.every(item =>
+              Array.isArray(item)
+                ? isValidCoordinates(item)
+                : typeof item === 'number' && Number.isFinite(item)
+            )
+          }
+
           let geoJson: FeatureCollection | null = null;
           if (analysisResult.geoJson && analysisResult.geoJson.features) {
             geoJson = {
               type: 'FeatureCollection',
-              features: analysisResult.geoJson.features.map(f => {
-                let parsedCoords: any = f.coordinates;
+              features: analysisResult.geoJson.features.flatMap(f => {
+                let parsedCoords: unknown = f.coordinates;
                 if (typeof parsedCoords === 'string') {
                   try {
                     parsedCoords = JSON.parse(parsedCoords);
-                  } catch (e) {
-                    console.error('Failed to parse feature coordinates:', e);
+                  } catch (error) {
+                    console.error('Failed to parse feature coordinates:', error);
+                    return [];
                   }
                 }
-                return {
+
+                if (!isValidCoordinates(parsedCoords)) {
+                  console.warn('Skipping feature with invalid coordinates:', f.name);
+                  return [];
+                }
+
+                return [{
                   type: 'Feature',
                   geometry: {
                     type: f.geometryType as any,
-                    coordinates: parsedCoords
+                    coordinates: parsedCoords as any
                   },
                   properties: {
                     name: f.name,
                     description: f.description
                   }
-                };
+                }];
               })
             };
           }

--- a/lib/agents/researcher.tsx
+++ b/lib/agents/researcher.tsx
@@ -194,10 +194,12 @@ export async function researcher(
 
       case 'error':
         hasError = true
-        fullResponse += `\n\nError: Tool execution failed.`
+        fullResponse += `\n\nError: Model response generation failed.`
         break
     }
   }
+
+  streamText.done(fullResponse)
 
   messages.push({
     role: 'assistant',

--- a/lib/agents/resolution-search.tsx
+++ b/lib/agents/resolution-search.tsx
@@ -142,7 +142,7 @@ Use these user-drawn areas/lines as primary areas of interest for your analysis.
 4. **Coordinate Extraction:** If possible, confirm or refine the geocoordinates (latitude/longitude) of the center of the image.
 5. **COG Applicability:** Determine if this location would benefit from Cloud Optimized GeoTIFF (COG) analysis for high-precision temporal or spectral data.
 6. **News Integration:** Reference any recent news or events that may be relevant to the current state of the location.
-7. **Structured Output:** Return your findings in a structured JSON format including summary, geoJson (if any), news context, and any extracted coordinates or COG information. Use the provided schema. For geoJson features, emit only Point features with a flat [longitude, latitude] coordinates array; describe polygonal or line features in the summary instead.
+7. **Structured Output:** Return your findings in a structured JSON format including summary, geoJson (if any), news context, and any extracted coordinates or COG information. Use the provided schema. Encode each feature's coordinates as a valid JSON string: use [longitude, latitude] for Point features and nested arrays for Polygon or LineString features.
 
 Your analysis should be based on the visual information in the image, the temporal context provided, and your general knowledge. Do not attempt to access external websites or perform web searches beyond what has been provided.
 

--- a/lib/agents/resolution-search.tsx
+++ b/lib/agents/resolution-search.tsx
@@ -142,7 +142,7 @@ Use these user-drawn areas/lines as primary areas of interest for your analysis.
 4. **Coordinate Extraction:** If possible, confirm or refine the geocoordinates (latitude/longitude) of the center of the image.
 5. **COG Applicability:** Determine if this location would benefit from Cloud Optimized GeoTIFF (COG) analysis for high-precision temporal or spectral data.
 6. **News Integration:** Reference any recent news or events that may be relevant to the current state of the location.
-7. **Structured Output:** Return your findings in a structured JSON format including summary, geoJson (if any), news context, and any extracted coordinates or COG information. Use the provided schema.
+7. **Structured Output:** Return your findings in a structured JSON format including summary, geoJson (if any), news context, and any extracted coordinates or COG information. Use the provided schema. For geoJson features, emit only Point features with a flat [longitude, latitude] coordinates array; describe polygonal or line features in the summary instead.
 
 Your analysis should be based on the visual information in the image, the temporal context provided, and your general knowledge. Do not attempt to access external websites or perform web searches beyond what has been provided.
 

--- a/lib/schema/resolution-search.ts
+++ b/lib/schema/resolution-search.ts
@@ -14,7 +14,7 @@ export const resolutionSearchSchema = z.object({
     features: z.array(z.object({
       type: z.string().describe("Must be 'Feature'"),
       geometryType: z.string().describe("The type of geometry, e.g., 'Point', 'Polygon'"),
-      coordinates: z.string().describe('Coordinates for the geometry as a JSON stringified array, e.g., "[13.4, 52.5]" for Point or "[[[13.4, 52.5], [13.5, 52.5], [13.5, 52.6], [13.4, 52.5]]]" for Polygon'),
+      coordinates: z.array(z.number()).describe('Longitude and latitude numbers, e.g. [13.4, 52.5]'),
       name: z.string().describe('Name of the feature or point of interest'),
       description: z.string().optional().describe('Description of the feature')
     }))

--- a/lib/schema/resolution-search.ts
+++ b/lib/schema/resolution-search.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod'
 
-// OpenAI Structured Outputs does not reliably support unions of differently
-// nested arrays. Keep the model-facing contract flat and validate coordinates
-// before they reach GeoJSON consumers.
+// OpenAI-compatible structured outputs reject unions of differently nested
+// arrays. Keep coordinates as JSON text at the model boundary and parse plus
+// validate them before they reach GeoJSON consumers.
 
 export const resolutionSearchSchema = z.object({
   summary: z.string().describe('A detailed text summary of the analysis, including land feature classification, points of interest, relevant current news, and temporal context.'),
@@ -12,12 +12,12 @@ export const resolutionSearchSchema = z.object({
     type: z.string().describe("Must be 'FeatureCollection'"),
     features: z.array(z.object({
       type: z.string().describe("Must be 'Feature'"),
-      geometryType: z.string().describe("Use 'Point' for structured-output compatibility."),
-      coordinates: z.array(z.number()).describe('A longitude/latitude pair for a Point feature, e.g. [13.4, 52.5]. Do not nest this array.'),
+      geometryType: z.string().describe("The type of geometry, e.g., 'Point', 'Polygon'"),
+      coordinates: z.string().describe('Coordinates as a JSON-stringified array, e.g. "[13.4, 52.5]" for Point or "[[[13.4, 52.5], [13.5, 52.5], [13.5, 52.6], [13.4, 52.5]]]" for Polygon.'),
       name: z.string().describe('Name of the feature or point of interest'),
       description: z.string().optional().describe('Description of the feature')
     }))
-  }).optional().describe('A collection of point features to overlay on the map. Describe polygonal or line features in the summary instead.'),
+  }).optional().describe('A collection of points of interest and classified land features to be overlaid on the map.'),
 
   // Flattened top-level fields for better xAI compatibility
   extractedLatitude: z.number().optional().describe('The extracted latitude of the center of the image.'),

--- a/lib/schema/resolution-search.ts
+++ b/lib/schema/resolution-search.ts
@@ -14,10 +14,7 @@ export const resolutionSearchSchema = z.object({
     features: z.array(z.object({
       type: z.string().describe("Must be 'Feature'"),
       geometryType: z.string().describe("The type of geometry, e.g., 'Point', 'Polygon'"),
-      coordinates: z.array(z.number())
-        .or(z.array(z.array(z.number())))
-        .or(z.array(z.array(z.array(z.number()))))
-        .describe('Coordinates for the geometry'),
+      coordinates: z.string().describe('Coordinates for the geometry as a JSON stringified array, e.g., "[13.4, 52.5]" for Point or "[[[13.4, 52.5], [13.5, 52.5], [13.5, 52.6], [13.4, 52.5]]]" for Polygon'),
       name: z.string().describe('Name of the feature or point of interest'),
       description: z.string().optional().describe('Description of the feature')
     }))

--- a/lib/schema/resolution-search.ts
+++ b/lib/schema/resolution-search.ts
@@ -1,9 +1,8 @@
 import { z } from 'zod'
 
-// This schema is designed to be compatible with xAI's OpenAI-compatible endpoint.
-// We use a flattened structure and avoid z.literal (which generates JSON Schema 'const')
-// and z.any() to ensure maximum compatibility with xAI's schema validation.
-// This follows the pattern established in lib/schema/geospatial.tsx.
+// OpenAI Structured Outputs does not reliably support unions of differently
+// nested arrays. Keep the model-facing contract flat and validate coordinates
+// before they reach GeoJSON consumers.
 
 export const resolutionSearchSchema = z.object({
   summary: z.string().describe('A detailed text summary of the analysis, including land feature classification, points of interest, relevant current news, and temporal context.'),
@@ -13,12 +12,12 @@ export const resolutionSearchSchema = z.object({
     type: z.string().describe("Must be 'FeatureCollection'"),
     features: z.array(z.object({
       type: z.string().describe("Must be 'Feature'"),
-      geometryType: z.string().describe("The type of geometry, e.g., 'Point', 'Polygon'"),
-      coordinates: z.array(z.number()).describe('Longitude and latitude numbers, e.g. [13.4, 52.5]'),
+      geometryType: z.string().describe("Use 'Point' for structured-output compatibility."),
+      coordinates: z.array(z.number()).describe('A longitude/latitude pair for a Point feature, e.g. [13.4, 52.5]. Do not nest this array.'),
       name: z.string().describe('Name of the feature or point of interest'),
       description: z.string().optional().describe('Description of the feature')
     }))
-  }).optional().describe('A collection of points of interest and classified land features to be overlaid on the map.'),
+  }).optional().describe('A collection of point features to overlay on the map. Describe polygonal or line features in the summary instead.'),
 
   // Flattened top-level fields for better xAI compatibility
   extractedLatitude: z.number().optional().describe('The extracted latitude of the center of the image.'),
@@ -35,4 +34,4 @@ export const resolutionSearchSchema = z.object({
   })).optional().describe('List of recent news items relevant to the location.')
 })
 
-export type ResolutionSearch = z.infer<typeof resolutionSearchSchema>;
+export type ResolutionSearch = z.infer<typeof resolutionSearchSchema>

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -86,7 +86,7 @@ export async function getModel(requireVision: boolean = false) {
       const openai = createOpenAI({
         apiKey: openaiApiKey,
       });
-      return openai('gpt-5.6-terra');
+      return openai('gpt-4o');
     } catch (error) {
       console.warn('OpenAI API unavailable, falling back to next provider:', error);
     }


### PR DESCRIPTION
Fixed the model initialization and JSON schema incompatibilities causing OpenAI models and resolution search streaming to fail:
1. Replaced the non-existent fallback model 'gpt-5.6-terra' in `lib/utils/index.ts` with 'gpt-4o'.
2. Updated `resolutionSearchSchema` in `lib/schema/resolution-search.ts` to represent coordinates as a stringified JSON string rather than `.or()` union types, ensuring compatibility with OpenAI Structured Outputs (`strict: true`).
3. Updated `app/actions.tsx` to safely parse stringified feature coordinates into GeoJSON structures for UI rendering.

---
*PR created automatically by Jules for task [18339462429205626735](https://jules.google.com/task/18339462429205626735) started by @ngoiyaeric*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resolution-search map data handling by correctly interpreting and validating coordinate data.
  * Added safer fallback behavior when coordinate data is invalid or cannot be parsed.
  * Updated supported coordinate formatting for point, polygon, and linestring geometries.
  * Updated the default AI model for improved compatibility.
  * Clarified error messages when response generation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->