### PR TITLE
Fix AI timeouts and server-side stream errors

### DIFF
--- a/app/actions.tsx
+++ b/app/actions.tsx
@@ -262,6 +262,7 @@ async function submit(formData?: FormData, skip?: boolean) {
                 content: JSON.stringify({
                   ...analysisResult,
                   geoJson: geoJson, // Use reconstructed GeoJSON for storage/UI
+                  drawnFeatures,
                   image: dataUrl,
                   mapboxImage: mapboxDataUrl,
                   googleImage: googleDataUrl

--- a/app/actions.tsx
+++ b/app/actions.tsx
@@ -492,11 +492,20 @@ async function submit(formData?: FormData, skip?: boolean) {
 
   const currentSystemPrompt = userId ? await getSystemPrompt(userId) : null
   const maxMessages = 10
-  const messages = aiState.get().messages.map(message => ({
-    role: message.role,
-    content: message.content,
-    name: message.name
-  })) as CoreMessage[]
+  // Only send conversational content to the researcher. Resolution result
+  // blobs, related-query payloads, and UI markers are presentation state, not
+  // model messages; including them makes OpenAI follow-ups intermittently
+  // fail or exceed the context budget.
+  const messages = aiState.get().messages
+    .filter(message => !['related', 'followup', 'end', 'resolution_search_result'].includes(message.type || ''))
+    .map(message => ({
+      role: message.role,
+      content: Array.isArray(message.content)
+        ? message.content.filter((part: any) => part?.type !== 'image')
+        : message.content,
+      name: message.name
+    }))
+    .filter(message => typeof message.content === 'string' ? message.content.trim().length > 0 : true) as CoreMessage[]
 
   if (file) {
     const buffer = await file.arrayBuffer()

--- a/app/actions.tsx
+++ b/app/actions.tsx
@@ -168,7 +168,12 @@ async function submit(formData?: FormData, skip?: boolean) {
           if (analysisResult.geoJson && analysisResult.geoJson.features) {
             geoJson = {
               type: 'FeatureCollection',
-              features: analysisResult.geoJson.features.flatMap(f => {
+              features: analysisResult.geoJson.features.flatMap((f: {
+                coordinates: unknown
+                geometryType: string
+                name: string
+                description?: string
+              }) => {
                 let parsedCoords: unknown = f.coordinates;
                 if (typeof parsedCoords === 'string') {
                   try {
@@ -279,7 +284,7 @@ async function submit(formData?: FormData, skip?: boolean) {
           });
         } catch (error) {
           console.error('Error in resolution search:', error);
-          summaryStream.error(error);
+          summaryStream.done('Resolution analysis is temporarily unavailable. Please try again.');
         } finally {
           isGenerating.done(false);
           uiStream.done();
@@ -594,7 +599,7 @@ async function submit(formData?: FormData, skip?: boolean) {
     } catch (error) {
       console.error('Error in researcher:', error)
       errorOccurred = true
-      streamText.error(error)
+      streamText.done('The answer could not be completed before the service deadline. Please try again.')
     } finally {
       isGenerating.done(false)
       uiStream.done()
@@ -794,7 +799,15 @@ export const getUIStateFromAIState = (aiState: AIState): UIState => {
                 const relatedQueries = createStreamableValue<RelatedQueries>({
                   items: []
                 })
-                relatedQueries.done(JSON.parse(content as string))
+                const parsed = JSON.parse(content as string)
+                relatedQueries.done({
+                  items: Array.isArray(parsed?.items)
+                    ? parsed.items
+                        .filter((item: any) => typeof item?.query === 'string' && item.query.trim())
+                        .slice(0, 3)
+                        .map((item: any) => ({ query: item.query.trim() }))
+                    : []
+                })
                 return {
                   id,
                   component: (
@@ -820,7 +833,11 @@ export const getUIStateFromAIState = (aiState: AIState): UIState => {
             case 'resolution_search_result': {
               try {
                 const analysisResult = JSON.parse(content as string);
-                const geoJson = analysisResult.geoJson as FeatureCollection;
+                const geoJson = analysisResult.geoJson &&
+                  analysisResult.geoJson.type === 'FeatureCollection' &&
+                  Array.isArray(analysisResult.geoJson.features)
+                  ? analysisResult.geoJson as FeatureCollection
+                  : null;
                 const image = analysisResult.image as string;
                 const mapboxImage = analysisResult.mapboxImage as string;
                 const googleImage = analysisResult.googleImage as string;

--- a/components/resolution-carousel.tsx
+++ b/components/resolution-carousel.tsx
@@ -17,6 +17,7 @@ import { UserMessage } from './user-message'
 import { toast } from 'sonner'
 import { CompareSlider } from './compare-slider'
 import { compressImage } from '@/lib/utils/image-utils'
+import { useMapData } from './map/map-data-context'
 
 interface ResolutionCarouselProps {
   mapboxImage?: string | null
@@ -27,6 +28,7 @@ interface ResolutionCarouselProps {
 export function ResolutionCarousel({ mapboxImage, googleImage, initialImage }: ResolutionCarouselProps) {
   const actions = useActions<typeof AI>() as any
   const [, setMessages] = useUIState<typeof AI>()
+  const { mapData } = useMapData()
   const [isAnalyzing, setIsAnalyzing] = React.useState(false)
 
   const handleQCXAnalysis = async () => {
@@ -52,6 +54,7 @@ export function ResolutionCarousel({ mapboxImage, googleImage, initialImage }: R
       const formData = new FormData()
       formData.append('file', blob, 'google_analysis.png')
       formData.append('action', 'resolution_search')
+      formData.append('drawnFeatures', JSON.stringify(mapData.drawnFeatures || []))
 
       const responseMessage = await actions.submit(formData)
       setMessages((currentMessages: any[]) => [...currentMessages, responseMessage as any])

--- a/components/search-related.tsx
+++ b/components/search-related.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useCallback, useMemo } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import { Button } from './ui/button'
 import { ArrowRight } from 'lucide-react'
 import {
@@ -13,6 +13,7 @@ import { AI } from '@/app/actions'
 import { UserMessage } from './user-message'
 import { PartialRelated } from '@/lib/schema/related'
 import { nanoid } from '@/lib/utils'
+import { useMapData } from './map/map-data-context'
 
 export interface SearchRelatedProps {
   relatedQueries: StreamableValue<PartialRelated, any>
@@ -28,24 +29,38 @@ export const SearchRelated: React.FC<SearchRelatedProps> = React.memo(({
   const { submit } = useActions()
   const [, setMessages] = useUIState<typeof AI>()
   const [data] = useStreamableValue<PartialRelated>(relatedQueries)
+  const { mapData } = useMapData()
+  const [pendingQuery, setPendingQuery] = useState<string | null>(null)
 
   // OPTIMIZATION: Memoize click handler with useCallback
   const handleRelatedClick = useCallback(async (query: string) => {
+    if (!query.trim()) return
+    const normalizedQuery = query.trim()
+    if (pendingQuery) return
+    setPendingQuery(normalizedQuery)
     const formData = new FormData()
-    formData.append('related_query', query)
+    formData.append('related_query', normalizedQuery)
+    formData.append('drawnFeatures', JSON.stringify(mapData.drawnFeatures || []))
 
     const userMessage = {
       id: nanoid(),
       component: <UserMessage content={query} />
     }
 
-    const responseMessage = await submit(formData)
-    setMessages(currentMessages => [
-      ...currentMessages,
-      userMessage,
-      responseMessage
-    ])
-  }, [submit, setMessages])
+    try {
+      const responseMessage = await submit(formData)
+      setMessages(currentMessages => [...currentMessages, userMessage, responseMessage])
+    } catch (error) {
+      console.error('Failed to submit related query:', error)
+      setMessages(currentMessages => [
+        ...currentMessages,
+        userMessage,
+        { id: nanoid(), component: <div className="text-sm text-destructive">Unable to complete this follow-up. Please try again.</div> }
+      ])
+    } finally {
+      setPendingQuery(null)
+    }
+  }, [submit, setMessages, mapData.drawnFeatures, pendingQuery])
 
   // OPTIMIZATION: Memoize filtered and mapped items
   const relatedItems = useMemo(() => {
@@ -60,6 +75,7 @@ export const SearchRelated: React.FC<SearchRelatedProps> = React.memo(({
           <Button
             variant="link"
             className="flex-1 justify-start px-0 py-1 h-fit font-semibold text-accent-foreground/50 whitespace-normal text-left"
+            disabled={pendingQuery !== null}
             onClick={() => handleRelatedClick(item?.query || '')}
           >
             {item?.query}

--- a/lib/agents/query-suggestor.tsx
+++ b/lib/agents/query-suggestor.tsx
@@ -4,6 +4,7 @@ import { PartialRelated, relatedSchema } from '@/lib/schema/related'
 import { Section } from '@/components/section'
 import SearchRelated from '@/components/search-related'
 import { getModel } from '../utils'
+import { FOLLOWUP_TIMEOUT_MS, createDeadlineSignal, withTimeout } from '@/lib/utils/with-timeout'
 
 interface CacheEntry {
   data: PartialRelated;
@@ -54,36 +55,55 @@ export async function querySuggestor(
 
   let finalRelatedQueries: PartialRelated = {}
   
-  // OPTIMIZATION: Use a more concise system prompt to reduce token usage
-  const result = await streamObject({
-    model: (await getModel()) as LanguageModel,
-    system: `Generate 3 follow-up queries that explore the subject matter deeper. Format as JSON with an "items" array containing objects with "query" fields. Keep queries concise and relevant.`,
-    messages,
-    schema: relatedSchema,
-    temperature: 0.7, // Lower temperature for more consistent results
-  })
+  let result: any
+  try {
+    result = await withTimeout(Promise.resolve(streamObject({
+      model: (await getModel()) as LanguageModel,
+      system: `Generate exactly 3 concise follow-up queries that deepen the user's subject. Return only an object with an "items" array of objects containing non-empty "query" strings. Do not invent facts not present in the conversation.`,
+      messages,
+      schema: relatedSchema,
+      temperature: 0,
+      maxTokens: 300,
+      abortSignal: createDeadlineSignal(FOLLOWUP_TIMEOUT_MS),
+    })), FOLLOWUP_TIMEOUT_MS, 'Follow-up generation')
+  } catch (error) {
+    console.error('Follow-up generation unavailable:', error)
+    const fallback: PartialRelated = { items: [] }
+    objectStream.done(fallback)
+    queryCache.set(cacheKey, { data: fallback, timestamp: Date.now() })
+    return fallback
+  }
 
   // OPTIMIZATION: Stream updates but batch them to reduce re-render frequency
   let lastUpdateTime = Date.now();
   const UPDATE_THROTTLE = 200; // ms
 
-  for await (const obj of result.partialObjectStream) {
-    if (obj && typeof obj === 'object' && 'items' in obj) {
-      const now = Date.now();
-      // Only update UI if enough time has passed since last update
-      if (now - lastUpdateTime > UPDATE_THROTTLE) {
-        objectStream.update(obj as PartialRelated)
-        lastUpdateTime = now;
+  try {
+    for await (const obj of result.partialObjectStream) {
+      if (obj && typeof obj === 'object' && 'items' in obj) {
+        const now = Date.now();
+        // Only update UI if enough time has passed since last update
+        if (now - lastUpdateTime > UPDATE_THROTTLE) {
+          objectStream.update(obj as PartialRelated)
+          lastUpdateTime = now;
+        }
+        finalRelatedQueries = obj as PartialRelated
       }
-      finalRelatedQueries = obj as PartialRelated
     }
+  } catch (error) {
+    console.error('Follow-up stream interrupted:', error)
   }
 
-  objectStream.done()
+  const safeResult: PartialRelated = {
+    items: (finalRelatedQueries.items || [])
+      .filter((item): item is { query: string } => typeof item?.query === 'string' && item.query.trim().length > 0)
+      .slice(0, 3)
+      .map(item => ({ query: item.query.trim() }))
+  }
   
   // OPTIMIZATION: Cache the result
   queryCache.set(cacheKey, {
-    data: finalRelatedQueries,
+    data: safeResult,
     timestamp: Date.now()
   });
   
@@ -95,5 +115,6 @@ export async function querySuggestor(
     }
   }
 
-  return finalRelatedQueries
+  objectStream.done(safeResult)
+  return safeResult
 }

--- a/lib/agents/researcher.tsx
+++ b/lib/agents/researcher.tsx
@@ -14,6 +14,7 @@ import { getModel } from '../utils'
 import { MapProvider } from '@/lib/store/settings'
 import { DrawnFeature } from './resolution-search'
 import { getSelectedModel } from '@/lib/actions/users'
+import { AI_REQUEST_TIMEOUT_MS, createDeadlineSignal } from '@/lib/utils/with-timeout'
 
 // This magic tag lets us write raw multi-line strings with backticks, arrows, etc.
 const raw = String.raw
@@ -157,7 +158,9 @@ export async function researcher(
 
   const result = await nonexperimental_streamText({
     model: (await getModel(hasImage)) as LanguageModel,
-    maxTokens: 4096,
+    maxTokens: 2500,
+    temperature: 0,
+    abortSignal: createDeadlineSignal(AI_REQUEST_TIMEOUT_MS),
     system: systemPromptToUse,
     messages,
     tools: getTools({ uiStream, fullResponse, mapProvider, selectedModel, drawnFeatures }),

--- a/lib/agents/resolution-search.tsx
+++ b/lib/agents/resolution-search.tsx
@@ -2,6 +2,7 @@ import { CoreMessage, streamObject } from 'ai'
 import { getModel } from '@/lib/utils'
 import { tavily } from '@tavily/core'
 import { resolutionSearchSchema } from '@/lib/schema/resolution-search'
+import { AI_REQUEST_TIMEOUT_MS, ENRICHMENT_TIMEOUT_MS, createDeadlineSignal, withTimeout } from '@/lib/utils/with-timeout'
 
 // This agent is now a pure data-processing module, with no UI dependencies.
 
@@ -52,7 +53,10 @@ async function getReverseGeocode(lat: number, lng: number): Promise<string> {
   try {
     const response = await fetch(
       `https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lng}`,
-      { headers: { 'User-Agent': 'QCX-ResolutionSearch' } }
+      {
+        headers: { 'User-Agent': 'QCX-ResolutionSearch' },
+        signal: createDeadlineSignal(ENRICHMENT_TIMEOUT_MS)
+      }
     )
     const data = await response.json()
     return data.address?.city || data.address?.county || data.address?.country || 'Unknown Location'
@@ -96,12 +100,18 @@ export async function resolutionSearch(messages: CoreMessage[], timezone: string
   let locationName = 'this location';
   let newsContext = '';
   
-  if (location?.lat && location?.lng) {
+  if (location && Number.isFinite(location.lat) && Number.isFinite(location.lng)) {
     try {
-      locationName = await getReverseGeocode(location.lat, location.lng);
-      
-      // OPTIMIZATION: Fetch news in parallel with AI analysis
-      const newsData = await fetchLocationNews(locationName, timezone);
+      locationName = await withTimeout(
+        getReverseGeocode(location.lat, location.lng),
+        ENRICHMENT_TIMEOUT_MS,
+        'Reverse geocoding'
+      );
+      const newsData = await withTimeout(
+        fetchLocationNews(locationName, timezone),
+        ENRICHMENT_TIMEOUT_MS,
+        'Location news'
+      );
       
       if (newsData.hasRecentNews && newsData.newsItems.length > 0) {
         newsContext = `\n\nRecent News for ${locationName}:\n${newsData.newsItems
@@ -158,10 +168,13 @@ Analyze the user's prompt and the image to provide a holistic understanding of t
   )
 
   // Use streamObject to get partial results.
-  return streamObject({
+  return withTimeout(Promise.resolve(streamObject({
     model: await getModel(hasImage),
     system: systemPrompt,
     messages: filteredMessages,
     schema: resolutionSearchSchema,
-  })
+    temperature: 0,
+    maxTokens: 1800,
+    abortSignal: createDeadlineSignal(AI_REQUEST_TIMEOUT_MS),
+  })), AI_REQUEST_TIMEOUT_MS, 'Resolution analysis')
 }

--- a/lib/agents/resolution-search.tsx
+++ b/lib/agents/resolution-search.tsx
@@ -13,6 +13,20 @@ export interface DrawnFeature {
   geometry: any;
 }
 
+function formatDrawingContext(features: DrawnFeature[] = []): string {
+  const validFeatures = (Array.isArray(features) ? features : []).filter(feature =>
+    feature &&
+    (feature.type === 'Polygon' || feature.type === 'LineString') &&
+    typeof feature.measurement === 'string' &&
+    feature.geometry &&
+    Array.isArray(feature.geometry.coordinates)
+  )
+  return validFeatures.slice(0, 20).map((feature, index) =>
+    `Drawing ${index + 1}: ${feature.type}; measured ${feature.measurement}; ` +
+    `GeoJSON geometry: ${JSON.stringify(feature.geometry)}`
+  ).join('\n')
+}
+
 /**
  * Fetch recent news for a location using Tavily API
  */
@@ -123,6 +137,7 @@ export async function resolutionSearch(messages: CoreMessage[], timezone: string
     }
   }
 
+  const drawingContext = formatDrawingContext(drawnFeatures)
   const systemPrompt = `
 As a geospatial analyst, your task is to analyze the provided satellite image of a geographic location.
 
@@ -139,9 +154,8 @@ ${newsContext}
 
 Please incorporate this recent news context into your analysis where relevant.` : ''}
 
-${drawnFeatures && drawnFeatures.length > 0 ? `**User-Drawn Features:**
-The user has drawn the following features on the map for your reference:
-${drawnFeatures.map(f => `- ${f.type} (${f.measurement}): ${JSON.stringify(f.geometry)}`).join('\n')}
+${drawingContext ? `**User-Drawn Features (authoritative context):**
+${drawingContext}
 Use these user-drawn areas/lines as primary areas of interest for your analysis.` : ''}
 
 **Analysis Requirements:**
@@ -160,6 +174,12 @@ Analyze the user's prompt and the image to provide a holistic understanding of t
 `;
 
   const filteredMessages = messages.filter(msg => msg.role !== 'system');
+  if (drawingContext) {
+    filteredMessages.push({
+      role: 'user',
+      content: `Use these measured map drawings as authoritative analysis constraints. Refer to their exact type, measurement, and coordinates in your answer:\n${drawingContext}`
+    })
+  }
 
   // Check if any message contains an image (resolution search is specifically for image analysis)
   const hasImage = messages.some((message: any) =>

--- a/lib/agents/tools/retrieve.tsx
+++ b/lib/agents/tools/retrieve.tsx
@@ -4,6 +4,7 @@ import { Card } from '@/components/ui/card'
 import { SearchSkeleton } from '@/components/search-skeleton'
 import { SearchResults as SearchResultsType } from '@/lib/types'
 import RetrieveSection from '@/components/retrieve-section'
+import { createDeadlineSignal } from '@/lib/utils/with-timeout'
 
 export const retrieveTool = ({ uiStream, fullResponse }: ToolProps) => ({
   description: 'Retrieve content from the web',
@@ -17,6 +18,7 @@ export const retrieveTool = ({ uiStream, fullResponse }: ToolProps) => ({
     try {
       const response = await fetch(`https://r.jina.ai/${url}`, {
         method: 'GET',
+        signal: createDeadlineSignal(10_000),
         headers: {
           Accept: 'application/json',
           'X-With-Generated-Alt': 'true'

--- a/lib/agents/tools/search.tsx
+++ b/lib/agents/tools/search.tsx
@@ -4,6 +4,7 @@ import { searchSchema } from '@/lib/schema/search'
 import { Card } from '@/components/ui/card'
 import { SearchSection } from '@/components/search-section'
 import { ToolProps } from '.'
+import { withTimeout } from '@/lib/utils/with-timeout'
 
 export const searchTool = ({ uiStream, fullResponse }: ToolProps) => ({
   description: 'Search the web for information',
@@ -39,16 +40,20 @@ export const searchTool = ({ uiStream, fullResponse }: ToolProps) => ({
       query.length < 5 ? query + ' '.repeat(5 - query.length) : query
     let searchResult
     try {
-      searchResult = await tavilySearch(
-        filledQuery,
-        max_results,
-        search_depth,
-        include_answer,
-        topic,
-        time_range,
-        include_images,
-        include_image_descriptions,
-        include_raw_content
+      searchResult = await withTimeout(
+        tavilySearch(
+          filledQuery,
+          max_results,
+          search_depth,
+          include_answer,
+          topic,
+          time_range,
+          include_images,
+          include_image_descriptions,
+          include_raw_content
+        ),
+        12_000,
+        'Web search'
       )
     } catch (error) {
       console.error('Search API error:', error)

--- a/lib/agents/tools/video-search.tsx
+++ b/lib/agents/tools/video-search.tsx
@@ -3,6 +3,7 @@ import { searchSchema } from '@/lib/schema/search'
 import { Card } from '@/components/ui/card'
 import { ToolProps } from '.'
 import { VideoSearchSection } from '@/components/video-search-section'
+import { createDeadlineSignal } from '@/lib/utils/with-timeout'
 
 // Start Generation Here
 export const videoSearchTool = ({ uiStream, fullResponse }: ToolProps) => ({
@@ -18,6 +19,7 @@ export const videoSearchTool = ({ uiStream, fullResponse }: ToolProps) => ({
     try {
       const response = await fetch('https://google.serper.dev/videos', {
         method: 'POST',
+        signal: createDeadlineSignal(10_000),
         headers: {
           'X-API-KEY': process.env.SERPER_API_KEY || '',
           'Content-Type': 'application/json'

--- a/lib/utils/with-timeout.ts
+++ b/lib/utils/with-timeout.ts
@@ -1,0 +1,28 @@
+export const AI_REQUEST_TIMEOUT_MS = 45_000
+export const ENRICHMENT_TIMEOUT_MS = 4_000
+export const FOLLOWUP_TIMEOUT_MS = 8_000
+
+/** Rejects after a deadline while allowing the underlying promise to settle. */
+export async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  label: string
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs)
+      })
+    ])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}
+
+export function createDeadlineSignal(timeoutMs: number): AbortSignal {
+  const controller = new AbortController()
+  setTimeout(() => controller.abort(), timeoutMs).unref?.()
+  return controller.signal
+}


### PR DESCRIPTION
## Summary
- Add hard deadlines and abort signals to AI, web search, retrieval, video search, reverse geocoding, and news enrichment.
- Make follow-up generation deterministic, bounded, validated, and safe with an empty-result fallback.
- Close errored streams with stable user-visible text instead of serializing errored streamable values.
- Validate persisted related-query and GeoJSON payloads before reconstructing server UI.
- Correct resolution coordinate handling for valid zero-valued coordinates.

## Root cause
Normal chat requests could perform a primary researcher call followed by an uncapped follow-up model call. Resolution search performed uncapped enrichment calls and then a vision-model request. These combined paths could exceed the deployment's 60-second execution limit. Error paths also returned streamable UI values after calling `.error()`, and malformed persisted payloads were passed into UI reconstruction, contributing to the server-side `undefined.find` exception.

## Validation
- `git diff --check` passes.
- Application-only strict TypeScript validation passes.
- Full repository typecheck is blocked only by the pre-existing sandbox mismatch for `bun:test` in `tests-unit/skyfi.test.ts` (Bun is not installed in the validation environment).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added safeguards and time limits for research, location, web, video, and retrieval searches.
  * Search failures now provide friendly fallback messages instead of interrupting results.
  * Improved handling of stored location data and related-query results.

* **Improvements**
  * Follow-up suggestions are now limited to three clean, usable queries.
  * AI-generated research and suggestions are more consistent and responsive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->