### PR TITLE
feat: schedule Vercel redeployments and multimodal warm-ups

### DIFF
--- a/.github/workflows/scheduled-redeploy-warmup.yml
+++ b/.github/workflows/scheduled-redeploy-warmup.yml
@@ -1,0 +1,74 @@
+name: Scheduled Vercel Redeployment and Warm-up
+
+on:
+  schedule:
+    # GitHub Actions schedules use UTC. Run daily at 04:17 UTC.
+    - cron: '17 4 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: scheduled-production-redeploy
+  cancel-in-progress: false
+
+env:
+  QCX_URL: https://www.queue.cx
+
+jobs:
+  redeploy-and-warm:
+    name: Redeploy production and warm multimodal runtimes
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out the production branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trigger a fresh Vercel production deployment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git commit --allow-empty -m 'chore: scheduled production redeployment'
+          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:main
+
+      - name: Wait for the new deployment to serve health checks
+        run: |
+          set -euo pipefail
+          for attempt in $(seq 1 20); do
+            if curl --fail-with-body --silent --show-error --max-time 20 "${QCX_URL}/api/health"; then
+              printf '\nProduction health check passed on attempt %s.\n' "${attempt}"
+              exit 0
+            fi
+            printf 'Deployment is not ready yet; retrying in 15 seconds (attempt %s/20).\n' "${attempt}"
+            sleep 15
+          done
+          echo 'Production health check did not become ready within five minutes.' >&2
+          exit 1
+
+      - name: Warm multimodal feature runtimes
+        env:
+          QCX_WARMUP_TOKEN: ${{ secrets.QCX_WARMUP_TOKEN }}
+        run: |
+          set -euo pipefail
+          auth_args=()
+          if [ -n "${QCX_WARMUP_TOKEN}" ]; then
+            auth_args=(-H "Authorization: Bearer ${QCX_WARMUP_TOKEN}")
+          fi
+
+          for feature in image vision document video; do
+            echo "Warming ${feature} runtime..."
+            curl --fail-with-body --silent --show-error \
+              --retry 4 --retry-all-errors --retry-delay 10 --max-time 30 \
+              "${auth_args[@]}" \
+              "${QCX_URL}/api/warmup?feature=${feature}"
+            printf '\n'
+          done

--- a/app/api/warmup/route.ts
+++ b/app/api/warmup/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const SUPPORTED_FEATURES = ['image', 'vision', 'document', 'video'] as const
+type SupportedFeature = (typeof SUPPORTED_FEATURES)[number]
+
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
+function isSupportedFeature(value: string): value is SupportedFeature {
+  return SUPPORTED_FEATURES.includes(value as SupportedFeature)
+}
+
+function isAuthorized(request: NextRequest) {
+  const configuredToken = process.env.QCX_WARMUP_TOKEN
+
+  // The endpoint remains usable without configuration because it performs no
+  // provider calls and has no side effects. If a token is configured in Vercel,
+  // require it for scheduled requests.
+  if (!configuredToken) return true
+
+  const authorization = request.headers.get('authorization')
+  const suppliedToken = authorization?.startsWith('Bearer ')
+    ? authorization.slice('Bearer '.length)
+    : request.headers.get('x-qcx-warmup-token')
+
+  return suppliedToken === configuredToken
+}
+
+function responseBody(features: SupportedFeature[]) {
+  return {
+    status: 'ok',
+    service: 'QCX',
+    warmedFeatures: features.map((feature) => ({
+      feature,
+      status: 'ready',
+    })),
+    timestamp: new Date().toISOString(),
+    note: 'Runtime readiness only; no model inference, external provider call, or database write is performed.',
+  }
+}
+
+export async function GET(request: NextRequest) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ status: 'error', error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const requestedFeatures = request.nextUrl.searchParams.getAll('feature')
+  const features = requestedFeatures.length > 0 ? requestedFeatures : [...SUPPORTED_FEATURES]
+  const unsupported = features.filter((feature) => !isSupportedFeature(feature))
+
+  if (unsupported.length > 0) {
+    return NextResponse.json(
+      {
+        status: 'error',
+        error: 'Unsupported warm-up feature',
+        unsupportedFeatures: unsupported,
+        supportedFeatures: SUPPORTED_FEATURES,
+      },
+      { status: 400 },
+    )
+  }
+
+  return NextResponse.json(responseBody(features as SupportedFeature[]), {
+    status: 200,
+    headers: {
+      'Cache-Control': 'no-store',
+    },
+  })
+}
+
+export async function HEAD(request: NextRequest) {
+  if (!isAuthorized(request)) {
+    return new NextResponse(null, { status: 401 })
+  }
+
+  return new NextResponse(null, {
+    status: 200,
+    headers: {
+      'Cache-Control': 'no-store',
+    },
+  })
+}

--- a/docs/SCHEDULED_REDEPLOYMENTS.md
+++ b/docs/SCHEDULED_REDEPLOYMENTS.md
@@ -1,0 +1,27 @@
+# Scheduled Vercel Redeployments and Multimodal Warm-ups
+
+QCX now includes a GitHub Actions workflow at `.github/workflows/scheduled-redeploy-warmup.yml`. The workflow runs once per day at **04:17 UTC** and can also be started manually from the repository’s Actions page.
+
+| Stage | Behavior | Side effects |
+| --- | --- | --- |
+| Redeployment | Creates an empty commit on `main`, which triggers the existing Git-connected Vercel production deployment for the QCX project. | Adds one clearly labeled maintenance commit per run. |
+| Readiness check | Polls `https://www.queue.cx/api/health` for up to five minutes. | Read-only HTTP requests. |
+| Multimodal warm-up | Calls `/api/warmup` for `image`, `vision`, `document`, and `video`. | Read-only runtime warm-up; no model inference, provider request, database write, or user record is created. |
+
+## Optional endpoint protection
+
+The warm-up endpoint is intentionally safe without a secret because it performs no external provider calls and has no side effects. To restrict it, add a repository Actions secret named `QCX_WARMUP_TOKEN` and configure the same value as the `QCX_WARMUP_TOKEN` environment variable in the Vercel production environment. The workflow will then send the token as a bearer credential, while unauthorized requests receive HTTP 401.
+
+The endpoint accepts one or more `feature` query parameters from this allowlist: `image`, `vision`, `document`, and `video`. With no parameter, it reports all supported feature families. For example:
+
+```text
+GET /api/warmup?feature=image&feature=vision
+```
+
+## Operational notes
+
+GitHub Actions cron expressions are interpreted in UTC. GitHub may delay scheduled jobs during periods of high load, and scheduled workflows can be disabled by GitHub after extended repository inactivity. The workflow uses a concurrency lock so a manual run cannot overlap a scheduled production redeployment.
+
+This workflow assumes that the Vercel project remains connected to `QueueLab/QCX`, uses `main` as its production branch, and serves the production domain at `https://www.queue.cx`. If the production domain changes, update the `QCX_URL` value in the workflow before enabling the schedule.
+
+The warm-up is deliberately limited to **serverless runtime readiness**. It does not invoke image or vision models, upload files, query geospatial providers, or exercise authenticated user flows. Those operations can incur provider charges or require user credentials and should be tested separately in a controlled health-check or staging workflow.


### PR DESCRIPTION
## Summary

- Add a daily GitHub Actions schedule at 04:17 UTC with manual dispatch support.
- Trigger the linked Vercel production deployment through a labeled empty commit on `main`.
- Poll the production health endpoint and warm image, vision, document, and video runtimes.
- Add a side-effect-free `/api/warmup` endpoint with optional bearer-token protection.
- Document schedule operation, token configuration, and the deliberate no-inference behavior.

## Deployment assumptions

- Vercel project: `queuelab` (`prj_G5AjNXywRiMvv6HwYmUCSvBTxY6X`)
- Production branch: `main`
- Production URL: `https://www.queue.cx`

## Validation

- `git diff --check` passed.
- Workflow, endpoint, and documentation contract checks passed.
- Full TypeScript compilation is currently blocked by the sandbox checkout lacking installed repository dependencies; the compiler reported missing modules across the existing codebase rather than an error in the new route.

## Operational safety

The warm-up endpoint does not call model providers, write to the database, upload files, or create user records. It only confirms the serverless runtime is responding. If desired, set `QCX_WARMUP_TOKEN` both as a GitHub Actions secret and as a Vercel production environment variable to require bearer authentication.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a warm-up endpoint that reports readiness for image, vision, document, and video capabilities.
  * Added scheduled daily redeployment and runtime warm-up automation, with manual triggering support.
  * Added optional token protection and health checks for warm-up requests.

* **Documentation**
  * Added operational guidance for scheduled redeployments, readiness checks, and runtime warm-ups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->