### PR TITLE
fix: support protected qcx deployments in warmup

### DIFF
--- a/.github/workflows/scheduled-redeploy-warmup.yml
+++ b/.github/workflows/scheduled-redeploy-warmup.yml
@@ -13,9 +13,6 @@ concurrency:
   group: scheduled-production-redeploy
   cancel-in-progress: false
 
-env:
-  QCX_URL: https://www.queue.cx
-
 jobs:
   redeploy-and-warm:
     name: Redeploy production and warm multimodal runtimes
@@ -31,6 +28,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Trigger a fresh Vercel production deployment
+        id: redeploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -38,17 +36,60 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git commit --allow-empty -m 'chore: scheduled production redeployment'
+          deployment_sha="$(git rev-parse HEAD)"
+          echo "deployment_sha=${deployment_sha}" >> "${GITHUB_OUTPUT}"
           git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:main
 
-      - name: Wait for the new deployment to serve health checks
+      - name: Resolve the exact Vercel production deployment URL
+        id: deployment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          deployment_url=''
+          for attempt in $(seq 1 30); do
+            deployment_id="$(gh api \
+              "repos/${GITHUB_REPOSITORY}/deployments?sha=${{ steps.redeploy.outputs.deployment_sha }}&per_page=20" \
+              --jq '[.[] | select(.environment | startswith("Production")) | .id] | first // empty')"
+
+            if [ -n "${deployment_id}" ]; then
+              deployment_url="$(gh api \
+                "repos/${GITHUB_REPOSITORY}/deployments/${deployment_id}/statuses?per_page=20" \
+                --jq '[.[] | select(.state == "success")][0].target_url // empty')"
+            fi
+
+            if [ -n "${deployment_url}" ]; then
+              echo "Vercel production deployment is ready at ${deployment_url}"
+              echo "url=${deployment_url}" >> "${GITHUB_OUTPUT}"
+              exit 0
+            fi
+
+            printf 'Waiting for the Vercel production deployment (attempt %s/30).\n' "${attempt}"
+            sleep 10
+          done
+
+          echo 'Vercel did not report a successful production deployment within five minutes.' >&2
+          exit 1
+
+      - name: Wait for the new deployment to serve health checks
+        env:
+          QCX_URL: ${{ steps.deployment.outputs.url }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+        run: |
+          set -euo pipefail
+          if [ -z "${VERCEL_AUTOMATION_BYPASS_SECRET}" ]; then
+            echo 'VERCEL_AUTOMATION_BYPASS_SECRET is required because qcx deployments use Vercel Deployment Protection.' >&2
+            exit 1
+          fi
+
+          bypass_args=(-H "x-vercel-protection-bypass: ${VERCEL_AUTOMATION_BYPASS_SECRET}")
           for attempt in $(seq 1 20); do
-            if curl --fail-with-body --silent --show-error --max-time 20 "${QCX_URL}/api/health"; then
+            if curl --fail-with-body --silent --show-error --max-time 20 \
+              "${bypass_args[@]}" "${QCX_URL}/api/health"; then
               printf '\nProduction health check passed on attempt %s.\n' "${attempt}"
               exit 0
             fi
-            printf 'Deployment is not ready yet; retrying in 15 seconds (attempt %s/20).\n' "${attempt}"
+            printf 'Health endpoint is not ready yet; retrying in 15 seconds (attempt %s/20).\n' "${attempt}"
             sleep 15
           done
           echo 'Production health check did not become ready within five minutes.' >&2
@@ -56,9 +97,12 @@ jobs:
 
       - name: Warm multimodal feature runtimes
         env:
+          QCX_URL: ${{ steps.deployment.outputs.url }}
           QCX_WARMUP_TOKEN: ${{ secrets.QCX_WARMUP_TOKEN }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: |
           set -euo pipefail
+          bypass_args=(-H "x-vercel-protection-bypass: ${VERCEL_AUTOMATION_BYPASS_SECRET}")
           auth_args=()
           if [ -n "${QCX_WARMUP_TOKEN}" ]; then
             auth_args=(-H "Authorization: Bearer ${QCX_WARMUP_TOKEN}")
@@ -68,7 +112,7 @@ jobs:
             echo "Warming ${feature} runtime..."
             curl --fail-with-body --silent --show-error \
               --retry 4 --retry-all-errors --retry-delay 10 --max-time 30 \
-              "${auth_args[@]}" \
+              "${bypass_args[@]}" "${auth_args[@]}" \
               "${QCX_URL}/api/warmup?feature=${feature}"
             printf '\n'
           done

--- a/docs/SCHEDULED_REDEPLOYMENTS.md
+++ b/docs/SCHEDULED_REDEPLOYMENTS.md
@@ -4,13 +4,16 @@ QCX now includes a GitHub Actions workflow at `.github/workflows/scheduled-redep
 
 | Stage | Behavior | Side effects |
 | --- | --- | --- |
-| Redeployment | Creates an empty commit on `main`, which triggers the existing Git-connected Vercel production deployment for the QCX project. | Adds one clearly labeled maintenance commit per run. |
-| Readiness check | Polls `https://www.queue.cx/api/health` for up to five minutes. | Read-only HTTP requests. |
-| Multimodal warm-up | Calls `/api/warmup` for `image`, `vision`, `document`, and `video`. | Read-only runtime warm-up; no model inference, provider request, database write, or user record is created. |
+| Redeployment | Creates an empty commit on `main`, which triggers the existing Git-connected Vercel production deployment for the qcx project. | Adds one clearly labeled maintenance commit per run. |
+| Deployment URL lookup | Reads the successful Vercel production deployment status associated with the maintenance commit and uses its deployment-specific URL. | Read-only GitHub API requests. |
+| Readiness check | Polls the deployment URL’s `/api/health` endpoint for up to five minutes, using Vercel’s automation-bypass header. | Read-only HTTP requests. |
+| Multimodal warm-up | Calls the deployment URL’s `/api/warmup` endpoint for `image`, `vision`, `document`, and `video`. | Read-only runtime warm-up; no model inference, provider request, database write, or user record is created. |
 
-## Optional endpoint protection
+## Required Vercel access configuration
 
-The warm-up endpoint is intentionally safe without a secret because it performs no external provider calls and has no side effects. To restrict it, add a repository Actions secret named `QCX_WARMUP_TOKEN` and configure the same value as the `QCX_WARMUP_TOKEN` environment variable in the Vercel production environment. The workflow will then send the token as a bearer credential, while unauthorized requests receive HTTP 401.
+The qcx Vercel project currently uses Deployment Protection, so the workflow requires a Vercel **Protection Bypass for Automation** secret. Create the secret in the qcx project, then add the same value to the GitHub repository as an Actions secret named `VERCEL_AUTOMATION_BYPASS_SECRET`. The workflow sends it in the `x-vercel-protection-bypass` header, as documented in [Vercel’s official automation-bypass guide](https://vercel.com/docs/deployment-protection/methods-to-bypass-deployment-protection/protection-bypass-automation). Do not place this value in source control, workflow YAML, or a URL.
+
+The warm-up endpoint is intentionally safe without an application secret because it performs no external provider calls and has no side effects. To add defense in depth, add a repository Actions secret named `QCX_WARMUP_TOKEN` and configure the same value as the `QCX_WARMUP_TOKEN` environment variable in the Vercel production environment. The workflow will then send the token as a bearer credential, while unauthorized requests receive HTTP 401.
 
 The endpoint accepts one or more `feature` query parameters from this allowlist: `image`, `vision`, `document`, and `video`. With no parameter, it reports all supported feature families. For example:
 
@@ -22,6 +25,6 @@ GET /api/warmup?feature=image&feature=vision
 
 GitHub Actions cron expressions are interpreted in UTC. GitHub may delay scheduled jobs during periods of high load, and scheduled workflows can be disabled by GitHub after extended repository inactivity. The workflow uses a concurrency lock so a manual run cannot overlap a scheduled production redeployment.
 
-This workflow assumes that the Vercel project remains connected to `QueueLab/QCX`, uses `main` as its production branch, and serves the production domain at `https://www.queue.cx`. If the production domain changes, update the `QCX_URL` value in the workflow before enabling the schedule.
+This workflow assumes that the Vercel project remains connected to `QueueLab/QCX`, uses `main` as its production branch, and creates a GitHub deployment status with a successful Vercel production target URL. It does not depend on a fixed custom domain or deployment alias.
 
 The warm-up is deliberately limited to **serverless runtime readiness**. It does not invoke image or vision models, upload files, query geospatial providers, or exercise authenticated user flows. Those operations can incur provider charges or require user credentials and should be tested separately in a controlled health-check or staging workflow.


### PR DESCRIPTION
## Summary

- Resolve the exact Vercel production deployment URL from the GitHub deployment status associated with each scheduled maintenance commit.
- Send Vercel’s documented `x-vercel-protection-bypass` header for health and warm-up requests.
- Require the `VERCEL_AUTOMATION_BYPASS_SECRET` GitHub Actions secret because the qcx Vercel project is Deployment Protection-protected.
- Remove the incorrect fixed `www.queue.cx` target; the workflow now follows the qcx Vercel deployment created by each redeployment.
- Document the required secret setup and official Vercel reference.

## Validation

- Workflow, endpoint, and documentation contract checks passed.
- `git diff --check` passed.
- The merged production deployment reported a successful Vercel deployment status at `qcx-kt3bmy0n0-qcx.vercel.app`.
- Direct unauthenticated requests confirmed that qcx deployment protection blocks health and warm-up endpoints; the workflow now uses the official automation-bypass header to address that gate.

## Required repository configuration

Before the scheduled job can complete, create a Vercel Protection Bypass for Automation secret in the qcx project and add the same value to GitHub Actions as `VERCEL_AUTOMATION_BYPASS_SECRET`. The secret must not be committed to the repository.
