### PR TITLE
Update OpenAI model to gpt-6-astra

### DIFF
--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -75,7 +75,7 @@ export async function getModel(requireVision: boolean = false) {
           const openai = createOpenAI({
             apiKey: openaiApiKey,
           });
-          return openai('gpt-6-astra');
+          return openai('gpt-6');
         } else {
             console.error('User selected OpenAI model but OPENAI_API_KEY is not set.');
             throw new Error('Selected model is not configured.');
@@ -138,7 +138,7 @@ export async function getModel(requireVision: boolean = false) {
   const openai = createOpenAI({
     apiKey: openaiApiKey,
   });
-  return openai('gpt-6-astra');
+  return openai('gpt-6');
 }
 
 /**

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -68,13 +68,16 @@ export async function getModel(requireVision: boolean = false) {
             throw new Error('Selected model is not configured.');
         }
       case 'GPT-5.1':
+      case 'gpt-6-astra':
+      case 'GPT-6 Astra':
+      case 'GPT-6':
         if (openaiApiKey) {
           const openai = createOpenAI({
             apiKey: openaiApiKey,
           });
-          return openai('gpt-4o');
+          return openai('gpt-6-astra');
         } else {
-            console.error('User selected "GPT-5.1" but OPENAI_API_KEY is not set.');
+            console.error('User selected OpenAI model but OPENAI_API_KEY is not set.');
             throw new Error('Selected model is not configured.');
         }
     }
@@ -86,7 +89,7 @@ export async function getModel(requireVision: boolean = false) {
       const openai = createOpenAI({
         apiKey: openaiApiKey,
       });
-      return openai('gpt-4o');
+      return openai('gpt-6-astra');
     } catch (error) {
       console.warn('OpenAI API unavailable, falling back to next provider:', error);
     }
@@ -135,7 +138,7 @@ export async function getModel(requireVision: boolean = false) {
   const openai = createOpenAI({
     apiKey: openaiApiKey,
   });
-  return openai('gpt-4o');
+  return openai('gpt-6-astra');
 }
 
 /**


### PR DESCRIPTION
Updates the OpenAI model selection in lib/utils/index.ts to gpt-6-astra, including support for gpt-6-astra model switch cases.

---
*PR created automatically by Jules for task [805669275004264588](https://jules.google.com/task/805669275004264588) started by @ngoiyaeric*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Updated GPT-5.1, GPT-6 Astra, and GPT-6 selections to use the latest GPT-6 model.
  - Updated the default OpenAI fallback to use GPT-6 Astra.
  - Updated the final fallback to use GPT-6.
  - Improved OpenAI error messaging by removing references to a specific model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->