### PR TITLE
Switch primary font to Plus Jakarta Sans Google Font

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,7 @@
 import { ClerkProvider } from "@clerk/nextjs"
 import { UserSync } from "@/components/user-sync"
 import type { Metadata, Viewport } from 'next'
-import { Inter as FontSans, Poppins } from 'next/font/google'
+import { Plus_Jakarta_Sans as FontSans, Poppins } from 'next/font/google'
 import './globals.css'
 import 'katex/dist/katex.min.css';
 import { cn } from '@/lib/utils'


### PR DESCRIPTION
Switched the primary sans-serif Google font in `app/layout.tsx` from `Inter` to `Plus_Jakarta_Sans` while preserving `--font-sans` variable binding for Tailwind.

---
*PR created automatically by Jules for task [4239541224404119785](https://jules.google.com/task/4239541224404119785) started by @ngoiyaeric*