### PR TITLE
Fix system prompt persistence server-side authentication

### DIFF
--- a/app/actions.tsx
+++ b/app/actions.tsx
@@ -490,7 +490,7 @@ async function submit(formData?: FormData, skip?: boolean) {
     }
   }
 
-  const currentSystemPrompt = userId ? await getSystemPrompt(userId) : null
+  const currentSystemPrompt = await getSystemPrompt()
   const maxMessages = 10
   // Only send conversational content to the researcher. Resolution result
   // blobs, related-query payloads, and UI markers are presentation state, not

--- a/components/settings/components/settings.tsx
+++ b/components/settings/components/settings.tsx
@@ -95,10 +95,10 @@ export function Settings({ initialTab = "system-prompt" }: SettingsProps) {
 
   useEffect(() => {
     async function fetchData() {
-      if (!userId || authLoading) return;
+      if (authLoading || !user) return;
 
       const [existingPrompt, selectedModel] = await Promise.all([
-        getSystemPrompt(userId),
+        getSystemPrompt(),
         getSelectedModel(),
       ]);
 
@@ -110,7 +110,7 @@ export function Settings({ initialTab = "system-prompt" }: SettingsProps) {
       }
     }
     fetchData();
-  }, [form, userId, authLoading]);
+  }, [form, user, authLoading]);
 
   if (authLoading) {
     return <SettingsSkeleton />;
@@ -131,7 +131,7 @@ export function Settings({ initialTab = "system-prompt" }: SettingsProps) {
     try {
       // Save the system prompt and selected model
       const [promptSaveResult, modelSaveResult] = await Promise.all([
-        saveSystemPrompt(userId, data.systemPrompt),
+        saveSystemPrompt(data.systemPrompt),
         saveSelectedModel(data.selectedModel),
       ]);
 

--- a/lib/actions/chat.ts
+++ b/lib/actions/chat.ts
@@ -287,9 +287,9 @@ export async function updateDrawingContext(chatId: string, contextData: { drawnF
 }
 
 export async function saveSystemPrompt(
-  userId: string,
   prompt: string
 ): Promise<{ success?: boolean; error?: string }> {
+  const userId = await getCurrentUserIdOnServer()
   if (!userId) return { error: 'User ID is required' }
   if (!prompt) return { error: 'Prompt is required' }
 
@@ -298,6 +298,7 @@ export async function saveSystemPrompt(
       .set({ systemPrompt: prompt })
       .where(eq(users.id, userId));
 
+    revalidatePath('/settings');
     return { success: true }
   } catch (error) {
     console.error('saveSystemPrompt: Error:', error)
@@ -305,9 +306,8 @@ export async function saveSystemPrompt(
   }
 }
 
-export async function getSystemPrompt(
-  userId: string
-): Promise<string | null> {
+export async function getSystemPrompt(): Promise<string | null> {
+  const userId = await getCurrentUserIdOnServer()
   if (!userId) return null
 
   try {


### PR DESCRIPTION
Fixes the system prompt saving and loading by resolving the DB user ID server-side with getCurrentUserIdOnServer() instead of trusting client-supplied user IDs.

---
*PR created automatically by Jules for task [9942277450446460952](https://jules.google.com/task/9942277450446460952) started by @ngoiyaeric*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of user-specific system prompt settings.
  * Settings now refresh automatically after a system prompt is saved, ensuring the latest value is displayed.
  * Chat and settings actions now consistently use the currently signed-in user’s configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->