### PR TITLE
Support updating and deleting system prompts

### DIFF
--- a/components/settings/components/settings.tsx
+++ b/components/settings/components/settings.tsx
@@ -31,9 +31,6 @@ import { useUser } from '@clerk/nextjs'
 const settingsFormSchema = z.object({
   systemPrompt: z
     .string()
-    .min(10, {
-      message: "System prompt must be at least 10 characters.",
-    })
     .max(2000, {
       message: "System prompt cannot exceed 2000 characters.",
     }),
@@ -102,9 +99,8 @@ export function Settings({ initialTab = "system-prompt" }: SettingsProps) {
         getSelectedModel(),
       ]);
 
-      if (existingPrompt) {
-        form.setValue("systemPrompt", existingPrompt, { shouldValidate: true, shouldDirty: false });
-      }
+      form.setValue("systemPrompt", existingPrompt ?? "", { shouldValidate: true, shouldDirty: false });
+
       if (selectedModel) {
         form.setValue("selectedModel", selectedModel, { shouldValidate: true, shouldDirty: false });
       }

--- a/components/settings/components/system-prompt-form.tsx
+++ b/components/settings/components/system-prompt-form.tsx
@@ -4,9 +4,10 @@ import { FormField, FormItem, FormLabel, FormControl, FormDescription, FormMessa
 import { Textarea } from "@/components/ui/textarea"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
-import { Loader2, Sparkles } from "lucide-react"
+import { Loader2, Sparkles, Trash2 } from "lucide-react"
 import { useToast } from "@/components/ui/hooks/use-toast"
 import { startSystemPromptGeneration, getSystemPromptGenerationJob } from "@/lib/actions/system-prompt"
+import { deleteSystemPrompt } from "@/lib/actions/chat"
 
 interface SystemPromptFormProps {
   form: UseFormReturn<any>
@@ -145,7 +146,36 @@ export function SystemPromptForm({ form }: SystemPromptFormProps) {
         name="systemPrompt"
         render={({ field }) => (
           <FormItem>
-            <FormLabel>System</FormLabel>
+            <div className="flex items-center justify-between">
+              <FormLabel>System</FormLabel>
+              {systemPrompt?.trim() && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 text-xs text-destructive hover:text-destructive hover:bg-destructive/10"
+                  onClick={async () => {
+                    form.setValue("systemPrompt", "", { shouldValidate: true, shouldDirty: true })
+                    const res = await deleteSystemPrompt()
+                    if (res?.error) {
+                      toast({
+                        title: "Error deleting system prompt",
+                        description: res.error,
+                        variant: "destructive",
+                      })
+                    } else {
+                      toast({
+                        title: "System prompt cleared",
+                        description: "Your system prompt has been cleared and reset.",
+                      })
+                    }
+                  }}
+                >
+                  <Trash2 className="mr-1 h-3.5 w-3.5" />
+                  Delete Prompt
+                </Button>
+              )}
+            </div>
             <FormControl>
               <Textarea
                 placeholder="Enter the system prompt for your planetary copilot..."

--- a/lib/actions/chat.ts
+++ b/lib/actions/chat.ts
@@ -287,15 +287,16 @@ export async function updateDrawingContext(chatId: string, contextData: { drawnF
 }
 
 export async function saveSystemPrompt(
-  prompt: string
+  prompt: string | null
 ): Promise<{ success?: boolean; error?: string }> {
   const userId = await getCurrentUserIdOnServer()
   if (!userId) return { error: 'User ID is required' }
-  if (!prompt) return { error: 'Prompt is required' }
+
+  const trimmedPrompt = prompt && prompt.trim().length > 0 ? prompt.trim() : null
 
   try {
     await db.update(users)
-      .set({ systemPrompt: prompt })
+      .set({ systemPrompt: trimmedPrompt })
       .where(eq(users.id, userId));
 
     revalidatePath('/settings');
@@ -304,6 +305,10 @@ export async function saveSystemPrompt(
     console.error('saveSystemPrompt: Error:', error)
     return { error: 'Failed to save system prompt' }
   }
+}
+
+export async function deleteSystemPrompt(): Promise<{ success?: boolean; error?: string }> {
+  return saveSystemPrompt(null)
 }
 
 export async function getSystemPrompt(): Promise<string | null> {


### PR DESCRIPTION
Updated the system prompt schema to allow empty/cleared system prompts, updated server actions saveSystemPrompt and deleteSystemPrompt to handle null/empty values, and added a Delete Prompt button in the SystemPromptForm component.

---
*PR created automatically by Jules for task [8909027424537555777](https://jules.google.com/task/8909027424537555777) started by @ngoiyaeric*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to delete a saved system prompt directly from the settings form.
  * Added success and error notifications when deleting the system prompt.
* **Bug Fixes**
  * System prompts can now be saved empty, clearing the existing value without validation errors.
  * The settings form now correctly displays an empty field when no saved system prompt exists.
  * System prompt values are trimmed before being saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->