### PR TITLE
Fix system prompt autodelete while typing

### DIFF
--- a/components/settings/components/settings.tsx
+++ b/components/settings/components/settings.tsx
@@ -53,8 +53,7 @@ export type SettingsFormValues = z.infer<typeof settingsFormSchema>
 
 // Default values
 const defaultValues: Partial<SettingsFormValues> = {
-  systemPrompt:
-    "You are a planetary copilot, an AI assistant designed to help users with information about planets, space exploration, and astronomy. Provide accurate, educational, and engaging responses about our solar system and beyond.",
+  systemPrompt: "",
   selectedModel: "QCX-Terra",
   users: [],
   domain: "",
@@ -99,7 +98,12 @@ export function Settings({ initialTab = "system-prompt" }: SettingsProps) {
         getSelectedModel(),
       ]);
 
-      form.setValue("systemPrompt", existingPrompt ?? "", { shouldValidate: true, shouldDirty: false });
+      // Do not overwrite text that was entered while the initial request was in flight.
+      // This previously made a newly typed prompt appear to auto-delete when the request
+      // resolved with a null or stale value.
+      if (!form.getFieldState("systemPrompt").isDirty) {
+        form.setValue("systemPrompt", existingPrompt ?? "", { shouldValidate: true, shouldDirty: false });
+      }
 
       if (selectedModel) {
         form.setValue("selectedModel", selectedModel, { shouldValidate: true, shouldDirty: false });

--- a/components/settings/components/system-prompt-form.tsx
+++ b/components/settings/components/system-prompt-form.tsx
@@ -20,6 +20,7 @@ export function SystemPromptForm({ form }: SystemPromptFormProps) {
   const characterCount = systemPrompt?.length || 0
   const [jobId, setJobId] = useState<string | null>(null)
   const [isGenerating, setIsGenerating] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
 
   const handleGenerate = async () => {
     if (!domain) {
@@ -153,21 +154,28 @@ export function SystemPromptForm({ form }: SystemPromptFormProps) {
                   type="button"
                   variant="ghost"
                   size="sm"
+                  disabled={isDeleting}
                   className="h-8 text-xs text-destructive hover:text-destructive hover:bg-destructive/10"
                   onClick={async () => {
-                    form.setValue("systemPrompt", "", { shouldValidate: true, shouldDirty: true })
-                    const res = await deleteSystemPrompt()
-                    if (res?.error) {
-                      toast({
-                        title: "Error deleting system prompt",
-                        description: res.error,
-                        variant: "destructive",
-                      })
-                    } else {
+                    setIsDeleting(true)
+                    try {
+                      const res = await deleteSystemPrompt()
+                      if (res?.error) {
+                        toast({
+                          title: "Error deleting system prompt",
+                          description: res.error,
+                          variant: "destructive",
+                        })
+                        return
+                      }
+
+                      form.setValue("systemPrompt", "", { shouldValidate: true, shouldDirty: true })
                       toast({
                         title: "System prompt cleared",
                         description: "Your system prompt has been cleared and reset.",
                       })
+                    } finally {
+                      setIsDeleting(false)
                     }
                   }}
                 >


### PR DESCRIPTION
## Summary

Fixes the system prompt editor clearing text when a user starts typing during the initial settings load.

## Root cause

The settings component initialized the editor with a default prompt and then unconditionally replaced it when the asynchronous `getSystemPrompt()` request resolved. When the request returned an empty or stale value, text entered during that window appeared to auto-delete.

## Changes

- Start the custom system prompt editor empty until persisted data is loaded.
- Do not apply the asynchronous initial value when the field is already dirty.
- Only clear the editor after the explicit delete request succeeds.
- Disable the delete control while deletion is in progress.

## Validation

- `git diff --check` passed.
- ESLint and TypeScript validation completed successfully; the repository reports pre-existing warnings.
- Next.js production build reached page-data collection but is blocked by the existing missing `ENCRYPTION_KEY` environment variable in `/api/skyfi/callback`.

Fixes the reported system-prompt autodelete behavior.