### PR TITLE
Fix system prompt settings save & revalidation

### DIFF
--- a/components/settings/components/settings.tsx
+++ b/components/settings/components/settings.tsx
@@ -28,6 +28,13 @@ import { SettingsSkeleton } from './settings-skeleton'
 import { useUser } from '@clerk/nextjs'
 
 // Define the form schema with enum validation for roles
+const roleSchema = z.preprocess((val) => {
+  if (val === "admin" || val === "editor" || val === "viewer") {
+    return val
+  }
+  return "viewer"
+}, z.enum(["admin", "editor", "viewer"]))
+
 const settingsFormSchema = z.object({
   systemPrompt: z
     .string()
@@ -41,12 +48,12 @@ const settingsFormSchema = z.object({
     z.object({
       id: z.string(),
       email: z.string().email(),
-      role: z.enum(["admin", "editor", "viewer"]),
+      role: roleSchema,
     }),
   ),
   newUserEmail: z.string().email().optional().or(z.literal('')),
-  newUserRole: z.enum(["admin", "editor", "viewer"]).optional(),
-  domain: z.string().url().optional().or(z.literal('')),
+  newUserRole: roleSchema.optional(),
+  domain: z.string().optional(),
 })
 
 export type SettingsFormValues = z.infer<typeof settingsFormSchema>
@@ -161,6 +168,31 @@ export function Settings({ initialTab = "system-prompt" }: SettingsProps) {
     }
   }
 
+  function onInvalid(errors: any) {
+    const fieldMeta: Record<string, { label: string; tab: string }> = {
+      domain: { label: "Business Domain", tab: "System tab" },
+      systemPrompt: { label: "System Prompt", tab: "System tab" },
+      selectedModel: { label: "Plugin", tab: "Plugins tab" },
+      newUserEmail: { label: "New User Email", tab: "Users tab" },
+      newUserRole: { label: "New User Role", tab: "Users tab" },
+      users: { label: "Users", tab: "Users tab" },
+    }
+
+    const messages = Object.keys(errors).map((fieldKey) => {
+      const meta = fieldMeta[fieldKey]
+      if (meta) {
+        return `${meta.label} on ${meta.tab} is invalid`
+      }
+      return `${fieldKey} is invalid`
+    })
+
+    toast({
+      title: "Validation Error",
+      description: messages.join("\n"),
+      variant: "destructive",
+    })
+  }
+
   function onReset() {
     form.reset(defaultValues)
     setTheme('earth')
@@ -172,7 +204,7 @@ export function Settings({ initialTab = "system-prompt" }: SettingsProps) {
 
   return (
     <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)}>
+      <form onSubmit={form.handleSubmit(onSubmit, onInvalid)}>
         <div className="space-y-6">
           {/* Theme selector placed above the tabs */}
           <Card className="mb-6">

--- a/components/settings/components/system-prompt-form.tsx
+++ b/components/settings/components/system-prompt-form.tsx
@@ -162,7 +162,7 @@ export function SystemPromptForm({ form }: SystemPromptFormProps) {
                   variant="ghost"
                   size="sm"
                   disabled={isDeleting}
-                  className="h-8 text-xs text-destructive hover:text-destructive hover:bg-destructive/10"
+                  className="h-8 text-xs text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors"
                   onClick={async () => {
                     setIsDeleting(true)
                     try {

--- a/components/settings/components/system-prompt-form.tsx
+++ b/components/settings/components/system-prompt-form.tsx
@@ -23,7 +23,10 @@ export function SystemPromptForm({ form }: SystemPromptFormProps) {
   const [isDeleting, setIsDeleting] = useState(false)
 
   const handleGenerate = async () => {
-    if (!domain) {
+    const rawDomain = form.getValues("domain") || domain
+    const trimmedDomain = rawDomain ? rawDomain.trim() : ""
+
+    if (!trimmedDomain) {
       toast({
         title: "Domain required",
         description: "Please enter a domain to generate a system prompt.",
@@ -32,8 +35,12 @@ export function SystemPromptForm({ form }: SystemPromptFormProps) {
       return
     }
 
+    const normalizedDomain = /^https?:\/\//i.test(trimmedDomain)
+      ? trimmedDomain
+      : `https://${trimmedDomain}`
+
     setIsGenerating(true)
-    const result = await startSystemPromptGeneration(domain)
+    const result = await startSystemPromptGeneration(normalizedDomain)
 
     if (result.error) {
       toast({

--- a/lib/actions/chat.ts
+++ b/lib/actions/chat.ts
@@ -299,7 +299,8 @@ export async function saveSystemPrompt(
       .set({ systemPrompt: trimmedPrompt })
       .where(eq(users.id, userId));
 
-    revalidatePath('/settings');
+    revalidatePath('/');
+    revalidatePath('/search/[id]', 'page');
     return { success: true }
   } catch (error) {
     console.error('saveSystemPrompt: Error:', error)

--- a/lib/actions/system-prompt.ts
+++ b/lib/actions/system-prompt.ts
@@ -10,7 +10,7 @@ import { generateText } from 'ai';
 const domainSchema = z.string().min(1).refine((val) => {
   try {
     // Basic validation to check if it's a valid URL or domain
-    const url = val.startsWith('http') ? val : `https://${val}`;
+    const url = /^https?:\/\//i.test(val) ? val : `https://${val}`;
     new URL(url);
     return true;
   } catch (e) {
@@ -32,7 +32,7 @@ export async function startSystemPromptGeneration(domain: string) {
     return { error: validation.error.errors[0].message };
   }
 
-  const normalizedDomain = domain.startsWith('http') ? domain : `https://${domain}`;
+  const normalizedDomain = /^https?:\/\//i.test(domain) ? domain : `https://${domain}`;
 
   try {
     const job = await createJob({

--- a/lib/auth/get-current-user.ts
+++ b/lib/auth/get-current-user.ts
@@ -80,17 +80,42 @@ export async function resolveClerkUserToDbUser(clerkUserId: string): Promise<str
       }
     }
 
-    // 2.2 Create new user if no match found
-    const [newUser] = await db.insert(users).values({
-      clerkUserId,
-      email,
-      role: 'viewer',
-      firstName,
-      lastName,
-      avatarUrl,
-    }).returning({ id: users.id });
+    // 2.2 Create new user with conflict handling (idempotent upsert/insert)
+    try {
+      const [newUser] = await db.insert(users).values({
+        clerkUserId,
+        email,
+        role: 'viewer',
+        firstName,
+        lastName,
+        avatarUrl,
+      })
+      .onConflictDoNothing({ target: users.clerkUserId })
+      .returning({ id: users.id });
 
-    return newUser.id;
+      if (newUser?.id) {
+        return newUser.id;
+      }
+    } catch (insertError: any) {
+      // Treat unique-constraint race conditions as recoverable cases
+      console.warn('[Auth] Concurrent insert conflict encountered, recovering:', insertError?.message || insertError);
+    }
+
+    // Re-run SELECT by clerk_user_id (or email) after a conflict
+    const [recoveredUser] = await db.select({ id: users.id })
+      .from(users)
+      .where(
+        email
+          ? or(eq(users.clerkUserId, clerkUserId), eq(users.email, email))
+          : eq(users.clerkUserId, clerkUserId)
+      )
+      .limit(1);
+
+    if (recoveredUser) {
+      return recoveredUser.id;
+    }
+
+    return null;
   } catch (error) {
     console.error('[Auth] Error resolving Clerk user to DB user:', error);
     return null;


### PR DESCRIPTION
Fix system prompt settings form save issues across three phases:
1. Made domain optional in settingsFormSchema and added role preprocessing for 'viewer' default.
2. Added onInvalid callback on Settings form submit with destructive toast detailing failing fields and their tabs.
3. Implemented domain scheme normalization in SystemPromptForm handleGenerate.
4. Updated resolveClerkUserToDbUser to use onConflictDoNothing and fallback re-select to avoid race conditions.
5. Corrected revalidation targets in saveSystemPrompt to revalidate '/' and '/search/[id]'.

---
*PR created automatically by Jules for task [5880727123290768437](https://jules.google.com/task/5880727123290768437) started by @ngoiyaeric*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer form validation feedback, including field labels and the relevant settings tab.
  - Domain values are now normalized automatically by adding `https://` when no protocol is provided.
  - Domain entries no longer need to match a URL format.

- **Bug Fixes**
  - Saved system prompts now refresh related search and root pages immediately.
  - Improved handling of simultaneous new-user creation to prevent duplicate accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->